### PR TITLE
Handle label split for >16 zones

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
                             </div>
                             <div class="form-group">
                                 <label for="posnr" data-i18n="Pos.-Nr. (p):">Pos.-Nr. (p):</label>
-                                <input type="number" id="posnr" value="1" oninput="triggerPreviewUpdateDebounced()">
+                                <input type="text" id="posnr" value="1" oninput="triggerPreviewUpdateDebounced()">
                             </div>
                             <div class="form-group">
                                 <label for="gesamtlange" data-i18n="Gesamtlänge (l):">Gesamtlänge (l):</label>
@@ -314,6 +314,29 @@
                                     <div id="labelBarcodeText" style="display:none; font-size:8pt; word-break:break-all; font-family:monospace; color:#333;"></div>
                                 </div>
                             </div>
+        <div id="printableLabel2" style="width: 100mm; border: 1px dashed #999; background: white; padding: 4mm; box-sizing: border-box; margin-left: 10mm;">
+            <div style="display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 4mm;">
+                <h3 style="margin: 0; font-size: 14pt; font-weight: bold;"><span data-i18n="Pos‑Nr:">Pos‑Nr:</span> <span id="labelPosnr2"></span></h3>
+                <div style="display:flex;flex-direction:column;align-items:flex-end;font-size:14pt;font-weight:bold;color:#000;">
+                    <div id="labelKommNr2"></div>
+                    <div id="labelBuegelname2"></div>
+                </div>
+            </div>
+            <div class="label-grid" style="display: grid; grid-template-columns: auto 1fr; gap: 1mm 3mm; font-size: 10pt; margin-bottom: 4mm;">
+                <div data-i18n="Projekt:">Projekt:</div>
+                <div id="labelProjekt2"></div>
+                <div data-i18n="Auftrag:">Auftrag:</div>
+                <div id="labelAuftrag2"></div>
+                <div data-i18n="Länge:">Länge:</div>
+                <div id="labelGesamtlange2"></div>
+            </div>
+            <div id="labelBarcodeContainer2" style="text-align: center; margin-top: 4mm;"></div>
+            <div id="labelBarcodeFallback2" style="text-align: center; margin-top: 4mm;">
+                <img id="labelBarcodeImage2" src="" alt="Barcode" style="display:none; max-width:100%; height:auto;">
+                <div id="labelBarcodeText2" style="display:none; font-size:8pt; word-break:break-all; font-family:monospace; color:#333;"></div>
+            </div>
+        </div>
+</div>
                         </div>
                     </div>
                     <div class="button-group"

--- a/script.js
+++ b/script.js
@@ -1025,38 +1025,35 @@ const MAX_ZONES = 20; // maximale Anzahl an Zonen
 			        const buegelname = document.getElementById('buegelname').value.trim();
 			        const rezeptname = document.getElementById('rezeptname').value.trim();
 			
-			        // BVBS Header
-			        let bvbsCode = `BF2D@Hj${projekt}@r${KommNr}@i${auftrag}@p${posnr}@l${gesamtlange}@n${anzahl}@d${langdrahtDurchmesser}@e@g@s@v@`;
-			
-			        // PtGABBIE data section
-			        let ptgabbie = "PtGABBIE;";
-			        ptgabbie += `i${anfangsueberstand};`;
-			        ptgabbie += `f${endueberstand};`;
-			        zonesData.forEach(zone => {
-			            ptgabbie += `d${zone.dia};n${zone.num};p${zone.pitch};`;
-			        });
-			
-			        if (buegelname) ptgabbie += `s${buegelname};`;
-			        if (rezeptname) ptgabbie += `r${rezeptname};`;
-			
-			        // Remove trailing semicolon if no optional data was added
-			        if (ptgabbie.endsWith(';')) {
-			            ptgabbie = ptgabbie.slice(0, -1);
-			        }
-			
-			        ptgabbie += "@";
-			
-			        // Combine parts for checksum calculation
-			        const preChecksumCode = bvbsCode + ptgabbie + "C";
-			        const checksum = calculateChecksum(preChecksumCode);
-			        
-			        // Final code with checksum
-			        const finalBvbsCode = preChecksumCode + checksum + "@";
-			        
-			        document.getElementById('outputBvbsCode').value = finalBvbsCode + "\r\n";
-			
-			        updateBarcodeDebugInfo(`Generated BVBS code: ${finalBvbsCode}`);
-			        updateBarcodeDebugInfo(`Code length: ${finalBvbsCode.length}`);
+                                const buildCode = (zonesArr, startOv, endOv) => {
+                                    let head = `BF2D@Hj${projekt}@r${KommNr}@i${auftrag}@p${posnr}@l${gesamtlange}@n${anzahl}@d${langdrahtDurchmesser}@e@g@s@v@`;
+                                    let pt = "PtGABBIE;";
+                                    pt += `i${startOv};`;
+                                    pt += `f${endOv};`;
+                                    zonesArr.forEach(z => { pt += `d${z.dia};n${z.num};p${z.pitch};`; });
+                                    if (buegelname) pt += `s${buegelname};`;
+                                    if (rezeptname) pt += `r${rezeptname};`;
+                                    if (pt.endsWith(';')) pt = pt.slice(0,-1);
+                                    pt += "@";
+                                    const pre = head + pt + "C";
+                                    const cs = calculateChecksum(pre);
+                                    return pre + cs + "@";
+                                };
+
+                                let finalBvbsCode = buildCode(zonesData, anfangsueberstand, endueberstand);
+                                let finalBvbsCode2 = null;
+                                if (zonesData.length > 16) {
+                                    const firstZones = zonesData.slice(0,16);
+                                    const secondZones = zonesData.slice(16);
+                                    finalBvbsCode = buildCode(firstZones, anfangsueberstand, 0);
+                                    finalBvbsCode2 = buildCode(secondZones, zonesData[15].pitch, endueberstand);
+                                    document.getElementById('outputBvbsCode').value = finalBvbsCode + "\r\n" + finalBvbsCode2 + "\r\n";
+                                } else {
+                                    document.getElementById('outputBvbsCode').value = finalBvbsCode + "\r\n";
+                                }
+
+                                updateBarcodeDebugInfo(`Generated BVBS code: ${finalBvbsCode}`);
+                                updateBarcodeDebugInfo(`Code length: ${finalBvbsCode.length}${finalBvbsCode2 ? '/' + finalBvbsCode2.length : ''}`);
 			
 			        // Check for library before trying to use it
 			        if (typeof bwipjs === 'undefined') {
@@ -1167,23 +1164,38 @@ const MAX_ZONES = 20; // maximale Anzahl an Zonen
 			
 			// Update the printable label preview
 			// Update the printable label preview
-			function updateLabelPreview(barcodeSvg) {
-			document.getElementById('labelProjekt').textContent =
-			document.getElementById('projekt').value || '-';
-                        document.getElementById('labelKommNr').textContent =
-                        document.getElementById('KommNr').value || '-';
-                        document.getElementById('labelBuegelname').textContent =
-                        document.getElementById('buegelname').value || '-';
-			document.getElementById('labelAuftrag').textContent =
-			document.getElementById('auftrag').value || '-';
-			document.getElementById('labelGesamtlange').textContent =
-			(document.getElementById('gesamtlange').value || '-') + ' mm';
-			document.getElementById('labelPosnr').textContent =
-			document.getElementById('posnr').value || '-';
-			
-			const labelImage = document.getElementById('labelBarcodeImage');
-			const labelText  = document.getElementById('labelBarcodeText');
-			const bvbsCode   = document.getElementById('outputBvbsCode').value.trim();
+function updateLabelPreview(barcodeSvg) {
+                        const projekt = document.getElementById('projekt').value || '-';
+                        const KommNr  = document.getElementById('KommNr').value || '-';
+                        const buegelname = document.getElementById('buegelname').value || '-';
+                        const auftrag = document.getElementById('auftrag').value || '-';
+                        const gesamtlange = (document.getElementById('gesamtlange').value || '-') + ' mm';
+                        const posnr = document.getElementById('posnr').value || '-';
+                        const suffix = zonesData.length > 16 ? '/2' : '';
+
+                        const fillLabel = (idSuffix) => {
+                            document.getElementById('labelProjekt' + idSuffix).textContent = projekt;
+                            document.getElementById('labelKommNr' + idSuffix).textContent = KommNr;
+                            document.getElementById('labelBuegelname' + idSuffix).textContent = buegelname;
+                            document.getElementById('labelAuftrag' + idSuffix).textContent = auftrag;
+                            document.getElementById('labelGesamtlange' + idSuffix).textContent = gesamtlange;
+                            document.getElementById('labelPosnr' + idSuffix).textContent = posnr + suffix;
+                        };
+
+                        fillLabel('');
+                        const second = document.getElementById('printableLabel2');
+                        if (second) {
+                            if (zonesData.length > 16) {
+                                second.style.display = 'block';
+                                fillLabel('2');
+                            } else {
+                                second.style.display = 'none';
+                            }
+                        }
+
+                        const labelImage = document.getElementById('labelBarcodeImage');
+                        const labelText  = document.getElementById('labelBarcodeText');
+                        const bvbsCode   = document.getElementById('outputBvbsCode').value.trim();
 			
 			if (barcodeSvg) {
 			labelImage.src         = `data:image/svg+xml;base64,${btoa(barcodeSvg)}`;
@@ -1210,32 +1222,17 @@ const MAX_ZONES = 20; // maximale Anzahl an Zonen
 			
 			    // Event listeners
 			    document.getElementById('addZoneButton')?.addEventListener('click', () => addZone());
-			    document.getElementById('generateButton').addEventListener('click', () => {
-			// 1) BVBS-Code generieren und PDF417‑SVG im Card erzeugen
-			generateBvbsCodeAndBarcode();
-			
-			// 2) Label‑Felder updaten
-			const projekt       = document.getElementById('projekt').value;
-			const KommNr         = document.getElementById('KommNr').value;
-			const auftrag       = document.getElementById('auftrag').value;
-			const posnr         = document.getElementById('posnr').value;
-                        const anzahl        = document.getElementById('anzahl').value;
-                        const gesamtlange   = document.getElementById('gesamtlange').value;
-                        const buegelname    = document.getElementById('buegelname').value;
-			
-                        document.getElementById('labelProjekt').textContent      = projekt;
-                        document.getElementById('labelKommNr').textContent       = KommNr;
-                        document.getElementById('labelBuegelname').textContent   = buegelname || '-';
-                        document.getElementById('labelAuftrag').textContent      = auftrag;
-                        document.getElementById('labelPosnr').textContent        = posnr;
-                        document.getElementById('labelGesamtlange').textContent  = gesamtlange + ' mm';
-			
-			// 3) Canvas‑Barcode für das Druck‑Label erzeugen
-			const barcodeText = document.getElementById('outputBvbsCode').value.trim() || 'FallbackCode';
-			generateBarcodeToLabel(barcodeText);
-			const code = document.getElementById('outputBvbsCode').value.trim() || 'FallbackCode';
-			generateBarcodeToLabel(code);
-			});
+                            document.getElementById('generateButton').addEventListener('click', () => {
+                        generateBvbsCodeAndBarcode();
+                        updateLabelPreview();
+                        const codes = document.getElementById('outputBvbsCode').value.trim().split(/\r?\n/).filter(t => t);
+                        if (codes.length > 0) {
+                            generateBarcodeToLabel(codes[0], '');
+                            if (codes.length > 1) {
+                                generateBarcodeToLabel(codes[1], '2');
+                            }
+                        }
+                        });
 			
 			
 			
@@ -1319,9 +1316,14 @@ const MAX_ZONES = 20; // maximale Anzahl an Zonen
 			        }
 			    });
 			// ganz unten im DOMContentLoaded-Callback
-			updateLabelPreview();  
-			const initialCode = document.getElementById('outputBvbsCode').value.trim() || 'FallbackCode';
-			generateBarcodeToLabel(initialCode);
+                        updateLabelPreview();
+                        const initialCodes = document.getElementById('outputBvbsCode').value.trim().split(/\r?\n/).filter(t => t);
+                        if (initialCodes.length > 0) {
+                            generateBarcodeToLabel(initialCodes[0], '');
+                            if (initialCodes.length > 1) {
+                                generateBarcodeToLabel(initialCodes[1], '2');
+                            }
+                        }
 			
 			    // Set initial zones if none are loaded
 			    if (zonesData.length === 0) {

--- a/styles.css
+++ b/styles.css
@@ -922,7 +922,7 @@
 			text-overflow: clip;
 			}
 			}
-			#printableLabel {
+			#printableLabel, #printableLabel2 {
 			font-family: 'Arial', sans-serif;
 			color: #000;
 			background: #fff;
@@ -930,7 +930,7 @@
 			box-sizing: border-box;
 			overflow: hidden;
 			}
-			#printableLabel h3 {
+			#printableLabel h3, #printableLabel2 h3 {
 			text-align: center;
 			margin: 0 0 4mm 0;
 			font-size: 14pt;
@@ -956,10 +956,10 @@
 			body * {
 			visibility: hidden;
 			}
-			#printableLabel, #printableLabel * {
+			#printableLabel, #printableLabel2, #printableLabel *, #printableLabel2 * {
 			visibility: visible;
 			}
-			#printableLabel {
+			#printableLabel, #printableLabel2 {
 			position: absolute;
 			left: 0;
 			top: 0;
@@ -968,6 +968,7 @@
 			border: none;
 			width: 100%;
 			height: 100%;
+                        page-break-after: always;
 			}
 			}
 


### PR DESCRIPTION
## Summary
- change position number field to free text
- add second printable label when zone count exceeds 16
- adjust styles for new label and printing
- update BVBS code generation to split zones across two labels
- update label preview and barcode generation for two labels

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887bb4ce098832d99e8eb8dfc678a63