### PR TITLE
Handle label split for >16 zones

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
                             </div>
                             <div class="form-group">
                                 <label for="posnr" data-i18n="Pos.-Nr. (p):">Pos.-Nr. (p):</label>
-                                <input type="number" id="posnr" value="1" oninput="triggerPreviewUpdateDebounced()">
+                                <input type="text" id="posnr" value="1" oninput="triggerPreviewUpdateDebounced()">
                             </div>
                             <div class="form-group">
                                 <label for="gesamtlange" data-i18n="Gesamtlänge (l):">Gesamtlänge (l):</label>
@@ -314,6 +314,29 @@
                                     <div id="labelBarcodeText" style="display:none; font-size:8pt; word-break:break-all; font-family:monospace; color:#333;"></div>
                                 </div>
                             </div>
+        <div id="printableLabel2" style="width: 100mm; border: 1px dashed #999; background: white; padding: 4mm; box-sizing: border-box; margin-left: 10mm;">
+            <div style="display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 4mm;">
+                <h3 style="margin: 0; font-size: 14pt; font-weight: bold;"><span data-i18n="Pos‑Nr:">Pos‑Nr:</span> <span id="labelPosnr2"></span></h3>
+                <div style="display:flex;flex-direction:column;align-items:flex-end;font-size:14pt;font-weight:bold;color:#000;">
+                    <div id="labelKommNr2"></div>
+                    <div id="labelBuegelname2"></div>
+                </div>
+            </div>
+            <div class="label-grid" style="display: grid; grid-template-columns: auto 1fr; gap: 1mm 3mm; font-size: 10pt; margin-bottom: 4mm;">
+                <div data-i18n="Projekt:">Projekt:</div>
+                <div id="labelProjekt2"></div>
+                <div data-i18n="Auftrag:">Auftrag:</div>
+                <div id="labelAuftrag2"></div>
+                <div data-i18n="Länge:">Länge:</div>
+                <div id="labelGesamtlange2"></div>
+            </div>
+            <div id="labelBarcodeContainer2" style="text-align: center; margin-top: 4mm;"></div>
+            <div id="labelBarcodeFallback2" style="text-align: center; margin-top: 4mm;">
+                <img id="labelBarcodeImage2" src="" alt="Barcode" style="display:none; max-width:100%; height:auto;">
+                <div id="labelBarcodeText2" style="display:none; font-size:8pt; word-break:break-all; font-family:monospace; color:#333;"></div>
+            </div>
+        </div>
+</div>
                         </div>
                     </div>
                     <div class="button-group"

--- a/styles.css
+++ b/styles.css
@@ -922,15 +922,18 @@
 			text-overflow: clip;
 			}
 			}
-			#printableLabel {
-			font-family: 'Arial', sans-serif;
-			color: #000;
-			background: #fff;
-			padding: 4mm;
-			box-sizing: border-box;
-			overflow: hidden;
-			}
-			#printableLabel h3 {
+                        #printableLabel, #printableLabel2 {
+                        font-family: 'Arial', sans-serif;
+                        color: #000;
+                        background: #fff;
+                        padding: 4mm;
+                        box-sizing: border-box;
+                        overflow: hidden;
+                        }
+                        #printableLabel2 {
+                        display: none;
+                        }
+			#printableLabel h3, #printableLabel2 h3 {
 			text-align: center;
 			margin: 0 0 4mm 0;
 			font-size: 14pt;
@@ -956,10 +959,10 @@
 			body * {
 			visibility: hidden;
 			}
-			#printableLabel, #printableLabel * {
+			#printableLabel, #printableLabel2, #printableLabel *, #printableLabel2 * {
 			visibility: visible;
 			}
-			#printableLabel {
+			#printableLabel, #printableLabel2 {
 			position: absolute;
 			left: 0;
 			top: 0;
@@ -968,6 +971,7 @@
 			border: none;
 			width: 100%;
 			height: 100%;
+                        page-break-after: always;
 			}
 			}
 


### PR DESCRIPTION
## Summary
- change position number field to free text
- add second printable label when zone count exceeds 16
- adjust styles for new label and printing
- update BVBS code generation to split zones across two labels
- update label preview and barcode generation for two labels
- fix suffix numbering and barcode rendering on second label

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6887bb4ce098832d99e8eb8dfc678a63