### PR TITLE
Fix label print layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -285,12 +285,12 @@
                                 <div style="
                                     display: flex;
                                     justify-content: space-between;
-                                    align-items: baseline;
+                                    align-items: flex-start;
                                     margin-bottom: 4mm;
                                     ">
                                     <h3 style="
                                         margin: 0;
-                                        font-size: 14pt;
+                                        font-size: 16pt;
                                         font-weight: bold;
                                         ">
                                         <span data-i18n="Pos‑Nr:">Pos‑Nr:</span> <span id="labelPosnr"></span>
@@ -304,7 +304,7 @@
                                     display: grid;
                                     grid-template-columns: auto 1fr;
                                     gap: 1mm 3mm;
-                                    font-size: 10pt;
+                                    font-size: 12pt;
                                     margin-bottom: 4mm;
                                     ">
                                     <div data-i18n="Projekt:">Projekt:</div>
@@ -322,14 +322,14 @@
                                 </div>
                             </div>
         <div id="printableLabel2" style="width: 100mm; border: 1px dashed #999; background: white; padding: 4mm; box-sizing: border-box; margin-left: 10mm;">
-            <div style="display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 4mm;">
-                <h3 style="margin: 0; font-size: 14pt; font-weight: bold;"><span data-i18n="Pos‑Nr:">Pos‑Nr:</span> <span id="labelPosnr2"></span></h3>
+            <div style="display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 4mm;">
+                <h3 style="margin: 0; font-size: 16pt; font-weight: bold;"><span data-i18n="Pos‑Nr:">Pos‑Nr:</span> <span id="labelPosnr2"></span></h3>
                 <div style="display:flex;flex-direction:column;align-items:flex-end;font-size:14pt;font-weight:bold;color:#000;">
                     <div id="labelKommNr2"></div>
                     <div id="labelBuegelname2"></div>
                 </div>
             </div>
-            <div class="label-grid" style="display: grid; grid-template-columns: auto 1fr; gap: 1mm 3mm; font-size: 10pt; margin-bottom: 4mm;">
+            <div class="label-grid" style="display: grid; grid-template-columns: auto 1fr; gap: 1mm 3mm; font-size: 12pt; margin-bottom: 4mm;">
                 <div data-i18n="Projekt:">Projekt:</div>
                 <div id="labelProjekt2"></div>
                 <div data-i18n="Auftrag:">Auftrag:</div>

--- a/script.js
+++ b/script.js
@@ -1198,12 +1198,16 @@ function updateLabelPreview(barcodeSvg) {
                         if (second) {
                             if (zonesData.length > 16) {
                                 second.style.display = 'block';
+                                document.body.classList.add('two-page');
 
                                 fillLabel('2');
 
                             } else {
                                 second.style.display = 'none';
+                                document.body.classList.remove('two-page');
                             }
+                        } else {
+                            document.body.classList.remove('two-page');
                         }
 
                         const labelImage = document.getElementById('labelBarcodeImage');
@@ -1395,14 +1399,14 @@ function updateLabelPreview(barcodeSvg) {
 			// create a new canvas
 			const canvas = document.createElement('canvas');
 			try {
-			bwipjs.toCanvas(canvas, {
-			bcid:        'pdf417',    // Barcode‑Typ
-			text:        text,        // Dein BVBS‑Code
-			scaleX:      2,           // breit
-			scaleY:      3,           // hoch
-			height:      10,          // Stirrup‑Höhe
-			includetext: false        // kein Text unterm Barcode
-			});
+                        bwipjs.toCanvas(canvas, {
+                        bcid:        'pdf417',    // Barcode‑Typ
+                        text:        text,        // Dein BVBS‑Code
+                        scaleX:      3,           // breit
+                        scaleY:      4,           // hoch
+                        height:      15,          // Stirrup‑Höhe
+                        includetext: false        // kein Text unterm Barcode
+                        });
 			container.appendChild(canvas);
 			} catch (err) {
 			console.error('Barcode Label Fehler:', err);

--- a/styles.css
+++ b/styles.css
@@ -932,19 +932,19 @@
 			overflow: hidden;
 			}
 
-			#printableLabel h3, #printableLabel2 h3 {
-			text-align: center;
-			margin: 0 0 4mm 0;
-			font-size: 14pt;
-			font-weight: bold;
-			}
-			.label-grid {
-			display: grid;
-			grid-template-columns: 1fr 2fr;
-			gap: 1mm 3mm;
-			font-size: 10pt;
-			margin-bottom: 4mm;
-			}
+                        #printableLabel h3, #printableLabel2 h3 {
+                        text-align: center;
+                        margin: 0 0 4mm 0;
+                        font-size: 16pt;
+                        font-weight: bold;
+                        }
+                        .label-grid {
+                        display: grid;
+                        grid-template-columns: 1fr 2fr;
+                        gap: 1mm 3mm;
+                        font-size: 12pt;
+                        margin-bottom: 4mm;
+                        }
 			.label-grid > div:nth-child(odd) {
 			font-weight: bold;
 			text-align: right;
@@ -980,23 +980,21 @@
 				overflow: visible; /* Sicherstellen, dass nichts abgeschnitten wird */
 			}
 
-			#printableLabel {
-				page-break-after: always; /* Nach dem ersten Label immer einen Seitenumbruch erzwingen */
-			}
+                        #printableLabel,
+                        #printableLabel2 {
+                                page-break-after: auto;
+                                page-break-before: auto;
+                        }
 
-			#printableLabel2 {
-				page-break-before: always; /* Das zweite Label immer auf einer neuen Seite beginnen lassen */
-				margin-left: 0 !important; /* Sicherstellen, dass kein linker Margin angewendet wird */
-				/* margin-top kann hier in der Druckansicht auch auf 0 gesetzt werden,
-				da page-break-before den Abstand zur vorherigen Seite regelt. */
-				margin-top: 0 !important;
-			}
+                        .two-page #printableLabel {
+                                page-break-after: always;
+                        }
 
 			/* Optionale Optimierungen für den Druckbereich (falls der Browser sie unterstützt) */
-			@page {
-				margin: 5mm; /* Setzt alle Seitenränder auf 5mm, um mehr Platz für das Label zu lassen */
-				size: auto; /* Die Seite auf die Größe des Inhalts anpassen, oder A4 wählen */
-			}
+                        @page {
+                                size: 100mm 60mm;
+                                margin: 0;
+                        }
 
 			/* Sicherstellen, dass Barcodes im Druck sichtbar sind und richtig skaliert werden */
 			#labelBarcodeContainer canvas,


### PR DESCRIPTION
## Summary
- adjust label header alignment and font sizes
- toggle `.two-page` class depending on label count
- increase barcode scale for better readability
- refine print CSS to remove extra pages and set label page size

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6887cb6709d4832d8eb9c6ac851f03e4