### PR TITLE
Fix barcode scaling and allow adjusting max zones

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,6 +117,10 @@
                                 <span class="input-feedback"></span>
                             </div>
                             <h4 style="font-size: .95rem; font-weight: 600; margin-top: 1rem; margin-bottom: .5rem; color: var(--heading-color);" data-i18n="Bügelzonen">Bügelzonen</h4>
+                            <div class="form-group">
+                                <label for="maxZonesInput" data-i18n="Max. Zonen">Max. Zonen</label>
+                                <input type="number" id="maxZonesInput" value="20" min="1" oninput="updateMaxZones(this.value)">
+                            </div>
                             <div class="zone-table-wrapper">
                                 <table id="zonesTable" class="full-width-table">
 									<thead>

--- a/script.js
+++ b/script.js
@@ -14,7 +14,7 @@
 			const SVG_TOTAL_DIM_FONT_SIZE = "15px";
 			const SVG_SINGLE_STIRRUP_FONT_SIZE = "13px";
 const NUM_ZONE_COLORS_AVAILABLE = 20;
-const MAX_ZONES = 20; // maximale Anzahl an Zonen
+let maxZones = 20; // maximale Anzahl an Zonen, per UI anpassbar
 			
 			// Highlight classes
 			const HIGHLIGHT_COLOR_CLASS_STROKE = 'highlight-stroke';
@@ -42,7 +42,7 @@ const MAX_ZONES = 20; // maximale Anzahl an Zonen
 			}
 			
 			// Helper function for input-specific feedback
-			function showInputFeedback(inputElement, message, type = 'info', duration = 3000) {
+                        function showInputFeedback(inputElement, message, type = 'info', duration = 3000) {
 			    let feedbackElement = inputElement.nextElementSibling;
 			    if (!feedbackElement || !feedbackElement.classList.contains('input-feedback')) {
 			        feedbackElement = document.createElement('span');
@@ -563,7 +563,7 @@ const MAX_ZONES = 20; // maximale Anzahl an Zonen
 			
 			// Add a new zone to the list
                         function addZone(dia = 8, num = 3, pitch = 150) {
-                            if (zonesData.length >= MAX_ZONES) {
+                            if (zonesData.length >= maxZones) {
                                 showFeedback('templateFeedback', 'Maximale Zonenanzahl erreicht.', 'warning', 3000);
                                 return;
                             }
@@ -574,11 +574,7 @@ const MAX_ZONES = 20; // maximale Anzahl an Zonen
                                 pitch: pitch
                             });
                             renderAllZones();
-
-                            if (zonesData.length >= MAX_ZONES) {
-                                const btn = document.getElementById('addZoneButton');
-                                if (btn) btn.disabled = true;
-                            }
+                            updateAddZoneButtonState();
 			
 			    // Scroll to the new zone and briefly highlight it
 			    setTimeout(() => {
@@ -620,11 +616,21 @@ const MAX_ZONES = 20; // maximale Anzahl an Zonen
 			        setHighlightedZone(null, false);
                             }
                             renderAllZones();
-                            if (zonesData.length < MAX_ZONES) {
-                                const btn = document.getElementById('addZoneButton');
-                                if (btn) btn.disabled = false;
-                            }
+                            updateAddZoneButtonState();
                             showFeedback('templateFeedback', 'Zone gelöscht.', 'success', 2000);
+                        }
+
+                        function updateAddZoneButtonState() {
+                            const btn = document.getElementById('addZoneButton');
+                            if (btn) btn.disabled = zonesData.length >= maxZones;
+                        }
+
+                        function updateMaxZones(value) {
+                            const parsed = parseInt(value, 10);
+                            if (Number.isInteger(parsed) && parsed >= 1) {
+                                maxZones = parsed;
+                            }
+                            updateAddZoneButtonState();
                         }
 			
 			// Debounce function to prevent excessive updates while typing
@@ -1238,7 +1244,12 @@ function updateLabelPreview(barcodeSvg) {
 			    loadTemplatesFromFile();
 			
 			    // Event listeners
-			    document.getElementById('addZoneButton')?.addEventListener('click', () => addZone());
+                            document.getElementById('addZoneButton')?.addEventListener('click', () => addZone());
+                            document.getElementById('maxZonesInput')?.addEventListener('input', (e) => updateMaxZones(e.target.value));
+                            const maxZonesEl = document.getElementById('maxZonesInput');
+                            if (maxZonesEl) {
+                                updateMaxZones(maxZonesEl.value);
+                            }
                             document.getElementById('generateButton').addEventListener('click', () => {
                         generateBvbsCodeAndBarcode();
                         updateLabelPreview();
@@ -1363,8 +1374,9 @@ function updateLabelPreview(barcodeSvg) {
 			        zonesData = initialZones;
 			    }
 			
-			    renderAllZones();
-			    drawCagePreview();
+                            renderAllZones();
+                            updateAddZoneButtonState();
+                            drawCagePreview();
 			    // 1) Label mit Feldern befüllen
 			    updateLabelPreview();
 			    // 2) echten Barcode erzeugen (SVG im PDF417‑Card und Canvas im Label)

--- a/styles.css
+++ b/styles.css
@@ -615,21 +615,23 @@
 			gap: .5rem;
 			}
 			/* Damit das Canvas im Label immer maximal 100% breit ist */
-			#labelBarcodeContainer canvas {
-			display: block;
-			max-width: 100%;
-			max-height: 120px;
-			height: auto;
-			margin: 0 auto;
-			}
-			/* Und falls Du statt Canvas das <img> nutzt, auch hier */
-			#labelBarcodeImage {
-			display: block;
-			max-width: 100%;
-			max-height: 120px;
-			height: auto;
-			margin: 0 auto;
-			}
+                        #labelBarcodeContainer canvas,
+                        #labelBarcodeContainer2 canvas {
+                        display: block;
+                        max-width: 100%;
+                        max-height: 120px;
+                        height: auto;
+                        margin: 0 auto;
+                        }
+                        /* Und falls Du statt Canvas das <img> nutzt, auch hier */
+                        #labelBarcodeImage,
+                        #labelBarcodeImage2 {
+                        display: block;
+                        max-width: 100%;
+                        max-height: 120px;
+                        height: auto;
+                        margin: 0 auto;
+                        }
 			.download-canvas-btn-container {
 			margin-top: .5rem;
 			text-align: right;
@@ -949,11 +951,12 @@
 			font-weight: bold;
 			text-align: right;
 			}
-			#labelBarcodeImage {
-			max-width: 100%;
-			height: 30px;
-			display: block;
-			}
+                        #labelBarcodeImage,
+                        #labelBarcodeImage2 {
+                        max-width: 100%;
+                        height: 30px;
+                        display: block;
+                        }
 			@media print {
 			body * {
 				visibility: hidden; /* Alles verstecken, außer den Druck-Labels */
@@ -997,13 +1000,15 @@
                         }
 
 			/* Sicherstellen, dass Barcodes im Druck sichtbar sind und richtig skaliert werden */
-			#labelBarcodeContainer canvas,
-			#labelBarcodeImage {
-				display: block;
-				max-width: 100%;
-				height: auto; /* Wichtig: Automatische Höhe für korrekte Skalierung */
-				margin: 0 auto;
-			}
+                        #labelBarcodeContainer canvas,
+                        #labelBarcodeContainer2 canvas,
+                        #labelBarcodeImage,
+                        #labelBarcodeImage2 {
+                                display: block;
+                                max-width: 100%;
+                                height: auto; /* Wichtig: Automatische Höhe für korrekte Skalierung */
+                                margin: 0 auto;
+                        }
 
 			/* Das Elternelement des Labels im Druck auf Breite setzen,
 			um das "Abschneiden" zu verhindern, falls es eine Layout-Einschränkung gab. */


### PR DESCRIPTION
## Summary
- fix the barcode scaling on the second label so it matches the first
- allow configuration of the maximum number of zones in the UI
- wire the new setting into zone handling logic

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6887ce0cede0832d8401fcab17db5074