### PR TITLE
Disable BVBS generation when second zone name missing

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,6 +158,7 @@
                             </svg>
                             <span data-i18n="BVBS Code & Barcode generieren">BVBS Code & Barcode generieren</span>
                         </button>
+                        <div id="generateError" class="info-text" style="margin-top: .5rem; min-height: 1.2em;"></div>
                     </div>
                 </div>
                 <div class="preview-column">

--- a/script.js
+++ b/script.js
@@ -118,7 +118,7 @@ function checkBarcodeLibraryStatus() {
 function updateGenerateButtonState() {
     const generateBtn = document.getElementById('generateButton');
     const buegelname2El = document.getElementById('buegelname2');
-    const errorEl = document.getElementById('barcodeError');
+    const errorEl = document.getElementById('generateError');
     if (!generateBtn || !buegelname2El) return;
     const needSecond = zonesData.length > zonesPerLabel;
     const hasName = buegelname2El.value.trim().length > 0;
@@ -1178,7 +1178,7 @@ function updateZonesPerLabel(value) {
                                 const rezeptname = document.getElementById('rezeptname').value.trim();
 
                                 if (zonesData.length > zonesPerLabel && !buegelname2) {
-                                    showFeedback('barcodeError', 'Fehler: Bügelname (s) - Zone 2 ist erforderlich.', 'error', 5000);
+                                    updateGenerateButtonState();
                                     return;
                                 }
 
@@ -1447,11 +1447,13 @@ function updateLabelPreview(barcodeSvg) {
                             }
                         }
                         });
+
+                            document.getElementById('buegelname2')?.addEventListener('input', () => updateGenerateButtonState());
 			
 			
 			
 			
-			    document.getElementById('copyBvbsButton')?.addEventListener('click', async () => {
+                            document.getElementById('copyBvbsButton')?.addEventListener('click', async () => {
                                 const output = document.getElementById('outputBvbsCode').value
                                     .split(/\r?\n/)
                                     .filter(line => line.startsWith('BF2'))
@@ -1547,14 +1549,15 @@ function updateLabelPreview(barcodeSvg) {
                             renderAllZones();
                             updateAddZoneButtonState();
                             drawCagePreview();
-			    // 1) Label mit Feldern befüllen
-			    updateLabelPreview();
-			    // 2) echten Barcode erzeugen (SVG im PDF417‑Card und Canvas im Label)
-			    generateBvbsCodeAndBarcode();
+                            // 1) Label mit Feldern befüllen
+                            updateLabelPreview();
+                            // 2) echten Barcode erzeugen (SVG im PDF417‑Card und Canvas im Label)
+                            generateBvbsCodeAndBarcode();
+                            updateGenerateButtonState();
 			
 			    
 			    // Check library status after a short delay to ensure it's loaded
-			    setTimeout(() => {
+                            setTimeout(() => {
 			        updateBarcodeStatus();
 			        if (!checkBarcodeLibraryStatus()) {
 			            updateBarcodeDebugInfo('bwip-js Bibliothek nicht verfügbar');

--- a/styles.css
+++ b/styles.css
@@ -89,16 +89,22 @@
 			background-color: var(--primary-color);
 			border-color: var(--primary-color);
 			}
-			.btn-primary:hover,
-			#generateButton:hover {
-			background-color: var(--primary-hover-color);
-			border-color: var(--primary-hover-color);
-			}
-			.btn-secondary {
-			color: var(--secondary-color);
-			background-color: #fff;
-			border-color: var(--border-color);
-			}
+                        .btn-primary:hover,
+                        #generateButton:hover {
+                        background-color: var(--primary-hover-color);
+                        border-color: var(--primary-hover-color);
+                        }
+                        #generateButton:disabled {
+                        background-color: var(--border-color);
+                        border-color: var(--border-color);
+                        cursor: not-allowed;
+                        opacity: .65;
+                        }
+                        .btn-secondary {
+                        color: var(--secondary-color);
+                        background-color: #fff;
+                        border-color: var(--border-color);
+                        }
 			.btn-secondary:hover {
 			color: var(--text-color);
 			background-color: var(--light-bg-color);


### PR DESCRIPTION
## Summary
- Grey out BVBS generation button when a second zone name is required but missing
- Show inline error below the button and keep it updated on input changes
- Add disabled styling for the generate button

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6894ad7be348832d91a429e954df32a1