### PR TITLE
Fix stirrup drawing overhang logic

### DIFF
--- a/script.js
+++ b/script.js
@@ -992,7 +992,7 @@ function updateZonesPerLabel(value) {
                                             let stirrupOffset = initialGap + j * pitch;
                                             const stirrupPos = zoneStart + stirrupOffset;
                                             const stirrupX = Math.round(PADDING_VISUAL + stirrupPos * scale);
-                                            if (stirrupPos <= totalLength - initialOverhang - finalOverhang + 1) {
+                                            if (stirrupPos <= totalLength - finalOverhang + 1) {
                                                 svgContent += `<line class="stirrup ${stirrupStrokeClass}" style="stroke-width:${highlightedStrokeWidth}px" x1="${stirrupX}" y1="${Math.round(centerY - STIRRUP_HEIGHT_VISUAL / 2)}" x2="${stirrupX}" y2="${Math.round(centerY + STIRRUP_HEIGHT_VISUAL / 2)}"/>`;
                                             }
                                         }


### PR DESCRIPTION
## Summary
- prevent start and end overhangs from reducing total length when rendering stirrups

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6894cbfd858c832db13c4fb3a8dc12f7