### PR TITLE
Fix first zone stirrup placement

### DIFF
--- a/script.js
+++ b/script.js
@@ -967,7 +967,7 @@ function updateZonesPerLabel(value) {
                                     const pitch = zone.pitch;
                                     const dia = zone.dia;
 
-                                    const initialGap = index === 0 ? 0 : pitch;
+                                    const initialGap = pitch > 0 ? pitch : 0;
                                     const spacingLength = numStirrups > 1 && pitch > 0 ? (numStirrups - 1) * pitch : 0;
                                     const zoneLength = initialGap + spacingLength;
                                     stirrupZoneTotalLength += zoneLength;


### PR DESCRIPTION
## Summary
- Ensure first zone stirrup spacing starts after initial pitch for consistent visualization

## Testing
- `npm test` *(fails: Missing script: "test"; no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_6894cddb0268832da460267d65a2bb11