### PR TITLE
Add PNG download buttons for labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,8 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/bwip-js/3.2.0/bwip-js.min.js"></script>
         <link rel="stylesheet" href="styles.css">
         <script src="i18n.js"></script>
-		<script src="script.js" defer></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
+                <script src="script.js" defer></script>
     </head>
     <body>
         <div class="app-header-wrapper">
@@ -296,57 +297,65 @@
                             </button>
                         </div>
                         <div id="labelPreviewContainer"
-                            style="display: flex; justify-content: center; padding: 1rem;
+                            style="display: flex; justify-content: center; gap: 10mm; padding: 1rem;
                             background-color: var(--light-bg-color);
                             border-radius: var(--border-radius);">
-                            <div id="printableLabel"
-                                style="
-                                width: 100mm;
-                                border: 1px dashed #999;
-                                background: white;
-                                padding: 4mm;
-                                box-sizing: border-box;
-                                ">
-                                <div style="
-                                    display: flex;
-                                    justify-content: space-between;
-                                    align-items: flex-start;
-                                    margin-bottom: 4mm;
+                            <div class="label-wrapper">
+                                <div id="printableLabel"
+                                    style="
+                                    width: 100mm;
+                                    border: 1px dashed #999;
+                                    background: white;
+                                    padding: 4mm;
+                                    box-sizing: border-box;
                                     ">
-                                    <h3 style="
-                                        margin: 0;
-                                        font-size: 16pt;
-                                        font-weight: bold;
+                                    <div style="
+                                        display: flex;
+                                        justify-content: space-between;
+                                        align-items: flex-start;
+                                        margin-bottom: 4mm;
                                         ">
-                                        <span id="descPosnr" data-i18n="Pos‑Nr:">Pos‑Nr:</span> <span id="labelPosnr"></span>
-                                    </h3>
-                                    <div style="display:flex;flex-direction:column;align-items:flex-end;font-size:14pt;font-weight:bold;color:#000;">
-                                        <div id="labelKommNr"></div>
-                                        <div id="labelBuegelname"></div>
+                                        <h3 style="
+                                            margin: 0;
+                                            font-size: 16pt;
+                                            font-weight: bold;
+                                            ">
+                                            <span id="descPosnr" data-i18n="Pos‑Nr:">Pos‑Nr:</span> <span id="labelPosnr"></span>
+                                        </h3>
+                                        <div style="display:flex;flex-direction:column;align-items:flex-end;font-size:14pt;font-weight:bold;color:#000;">
+                                            <div id="labelKommNr"></div>
+                                            <div id="labelBuegelname"></div>
+                                        </div>
+                                    </div>
+                                    <div class="label-grid" style="
+                                        display: grid;
+                                        grid-template-columns: auto 1fr;
+                                        gap: 1mm 3mm;
+                                        font-size: 12pt;
+                                        margin-bottom: 4mm;
+                                        ">
+                                        <div id="descProjekt" data-i18n="Projekt:">Projekt:</div>
+                                        <div id="labelProjekt"></div>
+                                        <div id="descAuftrag" data-i18n="Auftrag:">Auftrag:</div>
+                                        <div id="labelAuftrag"></div>
+                                        <div id="descLange" data-i18n="Länge:">Länge:</div>
+                                        <div id="labelGesamtlange"></div>
+                                    </div>
+                                    <div id="labelBarcodeContainer" style="text-align: center; margin-top: 4mm;">
+                                        </div>
+                                    <div id="labelBarcodeFallback" style="text-align: center; margin-top: 4mm;">
+                                        <img id="labelBarcodeImage" src="" alt="Barcode" style="display:none; max-width:100%; height:auto;">
+                                        <div id="labelBarcodeText" style="display:none; font-size:8pt; word-break:break-all; font-family:monospace; color:#333;"></div>
                                     </div>
                                 </div>
-                                <div class="label-grid" style="
-                                    display: grid;
-                                    grid-template-columns: auto 1fr;
-                                    gap: 1mm 3mm;
-                                    font-size: 12pt;
-                                    margin-bottom: 4mm;
-                                    ">
-                                    <div id="descProjekt" data-i18n="Projekt:">Projekt:</div>
-                                    <div id="labelProjekt"></div>
-                                    <div id="descAuftrag" data-i18n="Auftrag:">Auftrag:</div>
-                                    <div id="labelAuftrag"></div>
-                                    <div id="descLange" data-i18n="Länge:">Länge:</div>
-                                    <div id="labelGesamtlange"></div>
-                                </div>
-                                <div id="labelBarcodeContainer" style="text-align: center; margin-top: 4mm;">
-                                    </div>
-                                <div id="labelBarcodeFallback" style="text-align: center; margin-top: 4mm;">
-                                    <img id="labelBarcodeImage" src="" alt="Barcode" style="display:none; max-width:100%; height:auto;">
-                                    <div id="labelBarcodeText" style="display:none; font-size:8pt; word-break:break-all; font-family:monospace; color:#333;"></div>
-                                </div>
+                                <button type="button" class="label-save-btn download-label-btn" data-target="printableLabel" data-i18n-title="Label als PNG speichern" title="Label als PNG speichern">
+                                    <svg viewBox="0 0 24 24">
+                                        <path d="M17 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V7l-4-4zm-5 16c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3zm3-10H5V5h10v4z"></path>
+                                    </svg>
+                                </button>
                             </div>
-        <div id="printableLabel2" style="width: 100mm; border: 1px dashed #999; background: white; padding: 4mm; box-sizing: border-box; margin-left: 10mm;">
+                            <div class="label-wrapper">
+                                <div id="printableLabel2" style="width: 100mm; border: 1px dashed #999; background: white; padding: 4mm; box-sizing: border-box;">
             <div style="display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 4mm;">
                 <h3 style="margin: 0; font-size: 16pt; font-weight: bold;"><span id="descPosnr2" data-i18n="Pos‑Nr:">Pos‑Nr:</span> <span id="labelPosnr2"></span></h3>
                 <div style="display:flex;flex-direction:column;align-items:flex-end;font-size:14pt;font-weight:bold;color:#000;">
@@ -368,7 +377,13 @@
                 <div id="labelBarcodeText2" style="display:none; font-size:8pt; word-break:break-all; font-family:monospace; color:#333;"></div>
             </div>
         </div>
-</div>
+                                <button type="button" class="label-save-btn download-label-btn" data-target="printableLabel2" data-i18n-title="Label als PNG speichern" title="Label als PNG speichern">
+                                    <svg viewBox="0 0 24 24">
+                                        <path d="M17 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V7l-4-4zm-5 16c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3zm3-10H5V5h10v4z"></path>
+                                    </svg>
+                                </button>
+                            </div>
+                        </div>
                         </div>
                     </div>
                 </div>

--- a/lang/cz.json
+++ b/lang/cz.json
@@ -134,5 +134,6 @@
   "Templates aus localStorage geladen": "Šablony načteny z lokálního úložiště",
   "Abstand mm": "Rozteč mm",
   "ZPL anzeigen": "Zobrazit ZPL",
-  "ZPL Code": "ZPL kód"
+  "ZPL Code": "ZPL kód",
+  "Label als PNG speichern": "Uložit štítek jako PNG"
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -134,5 +134,6 @@
   "Templates aus localStorage geladen": "Templates aus localStorage geladen",
   "Abstand mm": "Abstand mm",
   "ZPL anzeigen": "ZPL-Code anzeigen",
-  "ZPL Code": "ZPL-Code"
+  "ZPL Code": "ZPL-Code",
+  "Label als PNG speichern": "Label als PNG speichern"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -134,5 +134,6 @@
   "Templates aus localStorage geladen": "Templates loaded from localStorage",
   "Abstand mm": "Pitch mm",
   "ZPL anzeigen": "Show ZPL",
-  "ZPL Code": "ZPL Code"
+  "ZPL Code": "ZPL Code",
+  "Label als PNG speichern": "Save label as PNG"
 }

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -134,5 +134,6 @@
   "Templates aus localStorage geladen": "Szablony załadowane z localStorage",
   "Abstand mm": "Rozstaw  mm",
   "ZPL anzeigen": "Pokaż ZPL",
-  "ZPL Code": "Kod ZPL"
+  "ZPL Code": "Kod ZPL",
+  "Label als PNG speichern": "Zapisz etykietę jako PNG"
 }

--- a/script.js
+++ b/script.js
@@ -383,10 +383,22 @@ function loadLabelLayout() {
                             document.body.removeChild(a);
                             URL.revokeObjectURL(url);
                             showFeedback('templateFeedback', i18n.t('lagen.json heruntergeladen! Bitte manuell in den Projektordner verschieben.'), 'info', 5000);
-                        }
+                          }
 
-                        // Trigger the hidden file input for importing templates
-                        function uploadTemplatesFromJson() {
+                          // Download a label as PNG using html2canvas
+                          function downloadLabelAsPng(labelId) {
+                              const label = document.getElementById(labelId);
+                              if (!label) return;
+                              html2canvas(label).then(canvas => {
+                                  const link = document.createElement('a');
+                                  link.href = canvas.toDataURL('image/png');
+                                  link.download = labelId + '.png';
+                                  link.click();
+                              });
+                          }
+
+                          // Trigger the hidden file input for importing templates
+                          function uploadTemplatesFromJson() {
                             const input = document.getElementById('templateFileInput');
                             if (input) {
                                 input.value = '';
@@ -1502,20 +1514,26 @@ function updateLabelPreview(barcodeSvg) {
 			            }
 			        }
 			    });
-			    document.getElementById('downloadSvgButton')?.addEventListener('click', () => {
-			        const svgElement = document.getElementById('cagePreviewSvg');
-			        if (!svgElement) return;
-			        const svgString = new XMLSerializer().serializeToString(svgElement);
-			        const blob = new Blob([svgString], { type: 'image/svg+xml' });
-			        const url = URL.createObjectURL(blob);
-			        const a = document.createElement('a');
-			        a.href = url;
-			        a.download = 'korb_vorschau.svg';
-			        document.body.appendChild(a);
-			        a.click();
-			        document.body.removeChild(a);
-			        URL.revokeObjectURL(url);
-			    });
+                            document.getElementById('downloadSvgButton')?.addEventListener('click', () => {
+                                const svgElement = document.getElementById('cagePreviewSvg');
+                                if (!svgElement) return;
+                                const svgString = new XMLSerializer().serializeToString(svgElement);
+                                const blob = new Blob([svgString], { type: 'image/svg+xml' });
+                                const url = URL.createObjectURL(blob);
+                                const a = document.createElement('a');
+                                a.href = url;
+                                a.download = 'korb_vorschau.svg';
+                                document.body.appendChild(a);
+                                a.click();
+                                document.body.removeChild(a);
+                                URL.revokeObjectURL(url);
+                            });
+                            document.querySelectorAll('.download-label-btn')?.forEach(btn => {
+                                btn.addEventListener('click', () => {
+                                    const target = btn.getAttribute('data-target');
+                                    if (target) downloadLabelAsPng(target);
+                                });
+                            });
                             document.getElementById('printLabelButton')?.addEventListener('click', () => {
                                 if (document.getElementById('outputBvbsCode').value.trim() === '') {
                                     showFeedback('barcodeError', 'Bitte generieren Sie zuerst den Code, um das Label zu drucken.', 'warning', 5000);

--- a/styles.css
+++ b/styles.css
@@ -642,11 +642,30 @@
                         height: auto;
                         margin: 0 auto;
                         }
-			.download-canvas-btn-container {
-			margin-top: .5rem;
-			text-align: right;
-			}
-			.zone-summary-table-container {
+.download-canvas-btn-container {
+                        margin-top: .5rem;
+                        text-align: right;
+                        }
+.label-wrapper {
+                        display: flex;
+                        flex-direction: column;
+                        align-items: center;
+                        }
+.label-save-btn {
+                        margin-top: .25rem;
+                        background: none;
+                        border: none;
+                        cursor: pointer;
+                        color: var(--secondary-color);
+                        }
+.label-save-btn:hover {
+                        color: var(--text-color);
+                        }
+.label-save-btn svg {
+                        width: 1.2em;
+                        height: 1.2em;
+                        }
+.zone-summary-table-container {
 			margin-top: 0;
 			padding: 0;
 			border: none;


### PR DESCRIPTION
## Summary
- add html2canvas and save buttons under labels to download them as PNG
- style and localize new label download controls

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6894e4e07db0832da37fe1cefe9588c2