### PR TITLE
Add production release workflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,9 +27,13 @@
                     <option value="cz">CZ</option>
                 </select>
                 </div>
+                <div class="nav-controls">
+                    <button id="showGeneratorBtn" class="btn-secondary" data-i18n="Generator">Generator</button>
+                    <button id="showProductionBtn" class="btn-secondary" data-i18n="Produktion">Produktion</button>
+                </div>
             </header>
         </div>
-        <div class="app-container">
+        <div id="generatorView" class="app-container">
             <div class="main-grid">
                 <div class="input-column card">
                     <div class="card-header">
@@ -68,6 +72,10 @@
                                 <label for="langdrahtDurchmesser" data-i18n="Längsdraht-Ø (d):">Längsdraht-Ø (d):</label>
                                 <input type="number" id="langdrahtDurchmesser" value="6" oninput="triggerPreviewUpdateDebounced(); validateNumberInput(this, 1, 'int', 'Längsdraht-Ø in mm (min. 1)');">
                                 <span class="input-feedback"></span>
+                            </div>
+                            <div class="form-group">
+                                <label for="startzeit" data-i18n="Startzeitpunkt">Startzeitpunkt</label>
+                                <input type="datetime-local" id="startzeit" oninput="triggerPreviewUpdateDebounced()">
                             </div>
                         </div>
                         <h3 class="section-title collapsible-header" data-i18n="PtGABBIE-Daten">PtGABBIE-Daten</h3>
@@ -384,9 +392,20 @@
                                 </button>
                             </div>
                         </div>
+                        <div class="button-group" style="justify-content: flex-end; margin-top: 1rem;">
+                            <button type="button" id="releaseButton" class="btn-primary" data-i18n="Freigeben">Freigeben</button>
+                        </div>
                         </div>
                     </div>
                 </div>
+            </div>
+        </div>
+        <div id="productionView" class="app-container" style="display:none;">
+            <div class="card">
+                <div class="card-header">
+                    <h2 class="card-title" data-i18n="Produktionsliste">Produktionsliste</h2>
+                </div>
+                <ul id="productionList" class="production-list"></ul>
             </div>
         </div>
         <footer style="text-align: center; margin-top: 2rem; padding-top: 1rem; border-top: 1px solid var(--border-color);">

--- a/lang/cz.json
+++ b/lang/cz.json
@@ -135,5 +135,10 @@
   "Abstand mm": "Rozteč mm",
   "ZPL anzeigen": "Zobrazit ZPL",
   "ZPL Code": "ZPL kód",
-  "Label als PNG speichern": "Uložit štítek jako PNG"
+  "Label als PNG speichern": "Uložit štítek jako PNG",
+  "Startzeitpunkt": "Startovní čas",
+  "Freigeben": "Uvolnit",
+  "Produktion": "Výroba",
+  "Generator": "Generátor",
+  "Produktionsliste": "Seznam výroby"
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -135,5 +135,10 @@
   "Abstand mm": "Abstand mm",
   "ZPL anzeigen": "ZPL-Code anzeigen",
   "ZPL Code": "ZPL-Code",
-  "Label als PNG speichern": "Label als PNG speichern"
+  "Label als PNG speichern": "Label als PNG speichern",
+  "Startzeitpunkt": "Startzeitpunkt",
+  "Freigeben": "Freigeben",
+  "Produktion": "Produktion",
+  "Generator": "Generator",
+  "Produktionsliste": "Produktionsliste"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -135,5 +135,10 @@
   "Abstand mm": "Pitch mm",
   "ZPL anzeigen": "Show ZPL",
   "ZPL Code": "ZPL Code",
-  "Label als PNG speichern": "Save label as PNG"
+  "Label als PNG speichern": "Save label as PNG",
+  "Startzeitpunkt": "Start Time",
+  "Freigeben": "Release",
+  "Produktion": "Production",
+  "Generator": "Generator",
+  "Produktionsliste": "Production List"
 }

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -135,5 +135,10 @@
   "Abstand mm": "Rozstaw  mm",
   "ZPL anzeigen": "Pokaż ZPL",
   "ZPL Code": "Kod ZPL",
-  "Label als PNG speichern": "Zapisz etykietę jako PNG"
+  "Label als PNG speichern": "Zapisz etykietę jako PNG",
+  "Startzeitpunkt": "Czas startu",
+  "Freigeben": "Zatwierdź",
+  "Produktion": "Produkcja",
+  "Generator": "Generator",
+  "Produktionsliste": "Lista produkcyjna"
 }

--- a/styles.css
+++ b/styles.css
@@ -1098,9 +1098,27 @@
                             position: relative;
                         }
 
-                        .label-edit-item {
-                            outline: 1px dashed var(--primary-color);
-                            cursor: move;
-                            user-select: none;
-                        }
+.label-edit-item {
+    outline: 1px dashed var(--primary-color);
+    cursor: move;
+    user-select: none;
+}
+
+.nav-controls {
+    display: flex;
+    gap: .5rem;
+    margin-left: 1rem;
+}
+
+.production-list {
+    list-style: none;
+    padding: 1rem;
+    margin: 0;
+}
+
+.production-item {
+    margin-bottom: 1rem;
+    border-bottom: 1px solid var(--border-color);
+    padding-bottom: 1rem;
+}
 


### PR DESCRIPTION
## Summary
- add navigation and start time input for releasing jobs
- capture label snapshot and queue released jobs in new production tab
- style navigation and production list with basic translations

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6894ed4eae54832d80b8e26bd9d3beda