### PR TITLE
feat: add filters and status management to production view

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -16,7 +16,6 @@
 const NUM_ZONE_COLORS_AVAILABLE = 20;
 let maxZones = 20; // maximale Anzahl an Zonen, per UI anpassbar
 let zonesPerLabel = 16; // Zonenanzahl Zone 1 (aufteilbar)
-let productionList = [];
 			
 			// Highlight classes
 			const HIGHLIGHT_COLOR_CLASS_STROKE = 'highlight-stroke';
@@ -818,40 +817,7 @@ function updateZonesPerLabel(value) {
     updateLabelPreview();
 }
 
-function renderProductionList() {
-    const list = document.getElementById('productionList');
-    if (!list) return;
-    list.innerHTML = '';
-    productionList.forEach(item => {
-        const li = document.createElement('li');
-        li.className = 'production-item';
-        li.innerHTML = `<div><strong>Start:</strong> ${item.startTime}</div>
-                        <div><strong>Projekt:</strong> ${item.projekt}</div>
-                        <div><strong>Komm:</strong> ${item.komm}</div>
-                        <div><strong>Auftrag:</strong> ${item.auftrag}</div>
-                        <div><strong>Pos-Nr:</strong> ${item.posnr}</div>`;
-        const img = document.createElement('img');
-        img.src = item.labelImg;
-        img.style.maxWidth = '200px';
-        img.style.marginTop = '0.5rem';
-        li.appendChild(img);
-        list.appendChild(li);
-    });
-}
 
-function showGeneratorView() {
-    const gen = document.getElementById('generatorView');
-    const prod = document.getElementById('productionView');
-    if (gen) gen.style.display = 'block';
-    if (prod) prod.style.display = 'none';
-}
-
-function showProductionView() {
-    const gen = document.getElementById('generatorView');
-    const prod = document.getElementById('productionView');
-    if (gen) gen.style.display = 'none';
-    if (prod) prod.style.display = 'block';
-}
 
                         // Debounce function to prevent excessive updates while typing
                         function triggerPreviewUpdateDebounced() {
@@ -1589,30 +1555,6 @@ function updateLabelPreview(barcodeSvg) {
                                 console.clear();
                                 showFeedback('barcodeError', 'Debug-Log gelöscht.', 'info', 2000);
                             });
-
-                            document.getElementById('showGeneratorBtn')?.addEventListener('click', () => showGeneratorView());
-                            document.getElementById('showProductionBtn')?.addEventListener('click', () => showProductionView());
-                            document.getElementById('releaseButton')?.addEventListener('click', async () => {
-                                const startTime = document.getElementById('startzeit')?.value;
-                                if (!startTime) {
-                                    showFeedback('barcodeError', 'Bitte Startzeitpunkt angeben.', 'warning', 3000);
-                                    return;
-                                }
-                                const labelElement = document.getElementById('printableLabel');
-                                const canvas = await html2canvas(labelElement);
-                                const imgData = canvas.toDataURL('image/png');
-                                productionList.push({
-                                    startTime,
-                                    projekt: document.getElementById('projekt').value,
-                                    komm: document.getElementById('KommNr').value,
-                                    auftrag: document.getElementById('auftrag').value,
-                                    posnr: document.getElementById('posnr').value,
-                                    labelImg: imgData
-                                });
-                                renderProductionList();
-                                showProductionView();
-                            });
-
                             // Initial validation and rendering
                             const inputsToValidateOnLoad = [{
 			        id: 'gesamtlange',
@@ -1676,7 +1618,6 @@ function updateLabelPreview(barcodeSvg) {
                                     updateBarcodeDebugInfo('bwip-js Bibliothek erfolgreich geladen');
                                 }
                             }, 1000);
-                            showGeneratorView();
                         });
 			
 			

--- a/i18n.js
+++ b/i18n.js
@@ -84,7 +84,7 @@ async function loadLanguage(lang) {
 
         // !!! WICHTIG !!!
         // Nach dem Laden einer neuen Sprache müssen alle Funktionen, die dynamische
-        // Textelemente in 'script.js' rendern, erneut aufgerufen werden.
+        // Textelemente in den Skripten rendern, erneut aufgerufen werden.
         // Dies stellt sicher, dass alle dynamisch generierten UI-Elemente
         // die neue Sprache übernehmen.
         // Die Funktionen müssen global verfügbar sein (z.B. nicht in einem lokalen Scope).
@@ -92,7 +92,8 @@ async function loadLanguage(lang) {
         if (typeof renderAllZones === 'function') renderAllZones();
         if (typeof drawCagePreview === 'function') drawCagePreview(); // Enthält die SVG-Texte mit Platzhaltern
         if (typeof updateLabelPreview === 'function') updateLabelPreview();
-        // Fügen Sie hier alle weiteren Funktionen aus script.js hinzu,
+        if (typeof renderProductionList === 'function') renderProductionList();
+        // Fügen Sie hier alle weiteren Funktionen aus den Skripten hinzu,
         // die UI-Elemente mit Text aktualisieren.
 
     } catch (error) {
@@ -164,7 +165,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const templateNameInput = document.getElementById('templateName');
     if (templateNameInput) {
         // Die i18n.t-Funktion sollte zu diesem Zeitpunkt bereits global definiert sein,
-        // da script.js nach i18n.js geladen wird und i18n.js window.i18n.t direkt definiert.
+        // da die Skripte nach i18n.js geladen werden und i18n.js window.i18n.t direkt definiert.
         templateNameInput.placeholder = i18n.t('Neuer Template-Name...');
     }
 });

--- a/index.html
+++ b/index.html
@@ -9,7 +9,8 @@
         <link rel="stylesheet" href="styles.css">
         <script src="i18n.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
-                <script src="script.js" defer></script>
+                <script src="generator.js" defer></script>
+        <script src="production.js" defer></script>
     </head>
     <body>
         <div class="app-header-wrapper">
@@ -404,6 +405,19 @@
             <div class="card">
                 <div class="card-header">
                     <h2 class="card-title" data-i18n="Produktionsliste">Produktionsliste</h2>
+                    <div class="production-controls">
+                        <input type="text" id="productionFilter" data-i18n-placeholder="Filter" placeholder="Filter">
+                        <select id="productionStatusFilter">
+                            <option value="all" data-i18n="Alle">Alle</option>
+                            <option value="pending" data-i18n="Offen">Offen</option>
+                            <option value="inProgress" data-i18n="In Arbeit">In Arbeit</option>
+                            <option value="done" data-i18n="Abgeschlossen">Abgeschlossen</option>
+                        </select>
+                        <select id="productionSort">
+                            <option value="startTime" data-i18n="Startzeit">Startzeit</option>
+                            <option value="projekt" data-i18n="Projekt">Projekt</option>
+                        </select>
+                    </div>
                 </div>
                 <ul id="productionList" class="production-list"></ul>
             </div>

--- a/lang/cz.json
+++ b/lang/cz.json
@@ -140,5 +140,16 @@
   "Freigeben": "Uvolnit",
   "Produktion": "Výroba",
   "Generator": "Generátor",
-  "Produktionsliste": "Seznam výroby"
+  "Produktionsliste": "Seznam výroby",
+  "Filter": "Filtr",
+  "Alle": "Vše",
+  "Offen": "Otevřené",
+  "In Arbeit": "Probíhá",
+  "Abgeschlossen": "Dokončeno",
+  "Starten": "Start",
+  "Abschließen": "Dokončit",
+  "Status": "Stav",
+  "Startzeit": "Čas startu",
+  "Projekt": "Projekt",
+  "Bitte Startzeitpunkt angeben.": "Zadejte čas startu."
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -140,5 +140,16 @@
   "Freigeben": "Freigeben",
   "Produktion": "Produktion",
   "Generator": "Generator",
-  "Produktionsliste": "Produktionsliste"
+  "Produktionsliste": "Produktionsliste",
+  "Filter": "Filter",
+  "Alle": "Alle",
+  "Offen": "Offen",
+  "In Arbeit": "In Arbeit",
+  "Abgeschlossen": "Abgeschlossen",
+  "Starten": "Starten",
+  "Abschließen": "Abschließen",
+  "Status": "Status",
+  "Startzeit": "Startzeit",
+  "Projekt": "Projekt",
+  "Bitte Startzeitpunkt angeben.": "Bitte Startzeitpunkt angeben."
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -140,5 +140,16 @@
   "Freigeben": "Release",
   "Produktion": "Production",
   "Generator": "Generator",
-  "Produktionsliste": "Production List"
+  "Produktionsliste": "Production List",
+  "Filter": "Filter",
+  "Alle": "All",
+  "Offen": "Open",
+  "In Arbeit": "In Progress",
+  "Abgeschlossen": "Completed",
+  "Starten": "Start",
+  "Abschließen": "Complete",
+  "Status": "Status",
+  "Startzeit": "Start Time",
+  "Projekt": "Project",
+  "Bitte Startzeitpunkt angeben.": "Please provide start time."
 }

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -140,5 +140,16 @@
   "Freigeben": "Zatwierdź",
   "Produktion": "Produkcja",
   "Generator": "Generator",
-  "Produktionsliste": "Lista produkcyjna"
+  "Produktionsliste": "Lista produkcyjna",
+  "Filter": "Filtr",
+  "Alle": "Wszystkie",
+  "Offen": "Otwarte",
+  "In Arbeit": "W toku",
+  "Abgeschlossen": "Zakończone",
+  "Starten": "Start",
+  "Abschließen": "Zakończ",
+  "Status": "Status",
+  "Startzeit": "Czas startu",
+  "Projekt": "Projekt",
+  "Bitte Startzeitpunkt angeben.": "Podaj czas startu."
 }

--- a/production.js
+++ b/production.js
@@ -1,0 +1,136 @@
+// production.js
+
+let productionList = [];
+let productionFilterText = '';
+let productionSortKey = 'startTime';
+let productionStatusFilter = 'all';
+
+function showGeneratorView() {
+    const gen = document.getElementById('generatorView');
+    const prod = document.getElementById('productionView');
+    if (gen) gen.style.display = 'block';
+    if (prod) prod.style.display = 'none';
+}
+
+function showProductionView() {
+    const gen = document.getElementById('generatorView');
+    const prod = document.getElementById('productionView');
+    if (gen) gen.style.display = 'none';
+    if (prod) prod.style.display = 'block';
+    renderProductionList();
+}
+
+function statusKey(status) {
+    switch (status) {
+        case 'inProgress': return 'In Arbeit';
+        case 'done': return 'Abgeschlossen';
+        default: return 'Offen';
+    }
+}
+
+function statusClass(status) {
+    switch (status) {
+        case 'inProgress': return 'in-progress';
+        case 'done': return 'done';
+        default: return 'pending';
+    }
+}
+
+function renderProductionList() {
+    const list = document.getElementById('productionList');
+    if (!list) return;
+    let items = productionList.filter(item => {
+        const textMatch = productionFilterText === '' ||
+            [item.projekt, item.komm, item.auftrag, item.posnr]
+                .some(f => f.toLowerCase().includes(productionFilterText));
+        const statusMatch = productionStatusFilter === 'all' || item.status === productionStatusFilter;
+        return textMatch && statusMatch;
+    });
+    items.sort((a, b) => {
+        if (productionSortKey === 'projekt') {
+            return a.projekt.localeCompare(b.projekt);
+        }
+        return a.startTime.localeCompare(b.startTime);
+    });
+    list.innerHTML = '';
+    items.forEach((item, index) => {
+        const li = document.createElement('li');
+        li.className = `production-item ${statusClass(item.status)}`;
+        li.innerHTML = `<div><strong>${i18n.t('Startzeit')}:</strong> ${item.startTime}</div>
+                        <div><strong>${i18n.t('Projekt')}:</strong> ${item.projekt}</div>
+                        <div><strong>Komm:</strong> ${item.komm}</div>
+                        <div><strong>${i18n.t('Auftrag')}:</strong> ${item.auftrag}</div>
+                        <div><strong>Pos-Nr:</strong> ${item.posnr}</div>
+                        <div><strong>${i18n.t('Status')}:</strong> ${i18n.t(statusKey(item.status))}</div>`;
+        const img = document.createElement('img');
+        img.src = item.labelImg;
+        img.style.maxWidth = '200px';
+        img.style.marginTop = '0.5rem';
+        img.style.cursor = 'pointer';
+        img.addEventListener('click', () => window.open(item.labelImg, '_blank'));
+        li.appendChild(img);
+        const btnGroup = document.createElement('div');
+        btnGroup.className = 'button-group';
+        if (item.status === 'pending') {
+            const startBtn = document.createElement('button');
+            startBtn.className = 'btn-secondary';
+            startBtn.textContent = i18n.t('Starten');
+            startBtn.addEventListener('click', () => {
+                item.status = 'inProgress';
+                renderProductionList();
+            });
+            btnGroup.appendChild(startBtn);
+        }
+        if (item.status === 'inProgress') {
+            const doneBtn = document.createElement('button');
+            doneBtn.className = 'btn-success';
+            doneBtn.textContent = i18n.t('Abschließen');
+            doneBtn.addEventListener('click', () => {
+                item.status = 'done';
+                renderProductionList();
+            });
+            btnGroup.appendChild(doneBtn);
+        }
+        li.appendChild(btnGroup);
+        list.appendChild(li);
+    });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    document.getElementById('showGeneratorBtn')?.addEventListener('click', () => showGeneratorView());
+    document.getElementById('showProductionBtn')?.addEventListener('click', () => showProductionView());
+    document.getElementById('releaseButton')?.addEventListener('click', async () => {
+        const startTime = document.getElementById('startzeit')?.value;
+        if (!startTime) {
+            showFeedback('barcodeError', i18n.t('Bitte Startzeitpunkt angeben.'), 'warning', 3000);
+            return;
+        }
+        const labelElement = document.getElementById('printableLabel');
+        const canvas = await html2canvas(labelElement);
+        const imgData = canvas.toDataURL('image/png');
+        productionList.push({
+            startTime,
+            projekt: document.getElementById('projekt').value,
+            komm: document.getElementById('KommNr').value,
+            auftrag: document.getElementById('auftrag').value,
+            posnr: document.getElementById('posnr').value,
+            labelImg: imgData,
+            status: 'pending'
+        });
+        renderProductionList();
+        showProductionView();
+    });
+    document.getElementById('productionFilter')?.addEventListener('input', e => {
+        productionFilterText = e.target.value.toLowerCase();
+        renderProductionList();
+    });
+    document.getElementById('productionSort')?.addEventListener('change', e => {
+        productionSortKey = e.target.value;
+        renderProductionList();
+    });
+    document.getElementById('productionStatusFilter')?.addEventListener('change', e => {
+        productionStatusFilter = e.target.value;
+        renderProductionList();
+    });
+    showGeneratorView();
+});

--- a/styles.css
+++ b/styles.css
@@ -1122,3 +1122,27 @@
     padding-bottom: 1rem;
 }
 
+.production-controls {
+    display: flex;
+    gap: .5rem;
+    flex-wrap: wrap;
+}
+
+.production-item.pending {
+    border-left: 4px solid var(--border-color);
+    padding-left: .5rem;
+}
+
+.production-item.in-progress {
+    border-left: 4px solid var(--warning-color);
+    padding-left: .5rem;
+    background-color: rgba(255,149,0,0.1);
+}
+
+.production-item.done {
+    border-left: 4px solid var(--success-color);
+    padding-left: .5rem;
+    background-color: rgba(52,199,89,0.1);
+    opacity: 0.7;
+}
+


### PR DESCRIPTION
## Summary
- split main script into generator and production modules
- add filter, sort, and status controls to production view
- allow starting and completing jobs with visual cues and clickable labels
- update translations and styles for new production features

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6894f73570b8832db7920de25ee5f870