### PR TITLE
Modernize header layout with flag dropdown and burger menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,23 +15,31 @@
     <body>
         <div class="app-header-wrapper">
             <header class="app-header">
-                <h1 class="app-title" data-i18n="Modern BVBS Korb Generator (MEP)">BVBS Korb Generator (MEP)</h1>
-                <div class="logo-area">
-                    <img id="appLogo" src="./gb.png" alt="Firmenlogo">
+                <div class="left-section">
+                    <button id="burgerMenu" class="burger-menu" aria-label="Menü">
+                        <svg viewBox="0 0 24 24">
+                            <path d="M3 6h18v2H3V6zm0 5h18v2H3v-2zm0 5h18v2H3v-2z" />
+                        </svg>
+                    </button>
+                    <h1 class="app-title" data-i18n="Modern BVBS Korb Generator (MEP)">BVBS Korb Generator (MEP)</h1>
                 </div>
-                
-                <div class="language-select">
-                <select id="languageSelect" onchange="setLanguage(this.value)">
-                    <option value="de">DE</option>
-                    <option value="en">EN</option>
-                    <option value="pl">PL</option>
-                    <option value="cz">CZ</option>
-                </select>
+                <div class="right-section">
+                    <div class="language-select">
+                        <select id="languageSelect" onchange="setLanguage(this.value)">
+                            <option value="de">🇩🇪 DE</option>
+                            <option value="en">🇬🇧 EN</option>
+                            <option value="pl">🇵🇱 PL</option>
+                            <option value="cz">🇨🇿 CZ</option>
+                        </select>
+                    </div>
+                    <div class="logo-area">
+                        <img id="appLogo" src="./gb.png" alt="Firmenlogo">
+                    </div>
                 </div>
-                <div class="nav-controls">
+                <nav id="navMenu" class="nav-menu">
                     <button id="showGeneratorBtn" class="btn-secondary" data-i18n="Generator">Generator</button>
                     <button id="showProductionBtn" class="btn-secondary" data-i18n="Produktion">Produktion</button>
-                </div>
+                </nav>
             </header>
         </div>
         <div id="generatorView" class="app-container">

--- a/production.js
+++ b/production.js
@@ -132,5 +132,14 @@ document.addEventListener('DOMContentLoaded', () => {
         productionStatusFilter = e.target.value;
         renderProductionList();
     });
+
+    document.getElementById('burgerMenu')?.addEventListener('click', () => {
+        document.getElementById('navMenu')?.classList.toggle('open');
+    });
+    document.querySelectorAll('#navMenu button').forEach(btn => {
+        btn.addEventListener('click', () => {
+            document.getElementById('navMenu')?.classList.remove('open');
+        });
+    });
     showGeneratorView();
 });

--- a/styles.css
+++ b/styles.css
@@ -14,7 +14,7 @@
     --text-color: #4A4A4A; /* Softer text color */
     --text-muted-color: #9B9B9B;
     --heading-color: #000000;
-    --header-text-color: #FFFFFF; /* White text for the header */
+    --header-text-color: #4A4A4A; /* Dark text for the header */
     --svg-text-color: #4A4A4A;
     --svg-dim-line-color: #9B9B9B;
     --hatch-line-color: #D8D8D8;
@@ -214,7 +214,7 @@ select {
 			}
 .app-header-wrapper {
     width: 100%;
-    background: linear-gradient(45deg, var(--primary-color), var(--primary-hover-color));
+    background: #f0f0f0;
     color: var(--header-text-color);
     box-shadow: var(--shadow-lg);
     margin-bottom: 2rem; /* Increased margin */
@@ -223,17 +223,24 @@ select {
     z-index: 1000;
     box-sizing: border-box;
 }
-			.app-header {
-			width: var(--page-content-width);
-			max-width: var(--page-content-max-pixel-width);
-			margin: 0 auto;
-			display: flex;
-			justify-content: space-between;
-			align-items: center;
-			height: 55px;
-			padding: 0 var(--page-side-padding);
-			box-sizing: border-box;
-			}
+.app-header {
+    width: var(--page-content-width);
+    max-width: var(--page-content-max-pixel-width);
+    margin: 0 auto;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    height: 55px;
+    padding: 0 var(--page-side-padding);
+    box-sizing: border-box;
+    position: relative;
+}
+.app-header .left-section,
+.app-header .right-section {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
 .app-header .app-title {
     font-size: 1.5rem; /* Larger font size */
     font-weight: 700; /* Bolder */
@@ -292,9 +299,10 @@ select {
 			.app-header .app-title {
 			font-size: 1.15rem;
 			}
-			#appLogo {
-			max-height: 26px;
-			}
+                        #appLogo {
+                        max-height: 26px;
+                        }
+}
 .app-header, .app-container {
     width: 95vw;
 }
@@ -304,7 +312,7 @@ select {
     color: var(--header-text-color);
 }
 .app-header .btn-secondary:hover {
-    background-color: rgba(255, 255, 255, 0.2);
+    background-color: rgba(0, 0, 0, 0.05);
     border-color: var(--header-text-color);
     color: var(--header-text-color);
 }
@@ -313,7 +321,35 @@ select {
     color: var(--header-text-color);
     border: 1px solid var(--header-text-color);
 }
+
+.burger-menu {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: .25rem;
+    display: flex;
+    align-items: center;
 }
+.burger-menu svg {
+    width: 24px;
+    height: 24px;
+    fill: var(--header-text-color);
+}
+.nav-menu {
+    position: absolute;
+    top: 55px;
+    left: 0;
+    right: 0;
+    background: #f0f0f0;
+    box-shadow: var(--shadow-md);
+    padding: 1rem;
+    display: none;
+    flex-direction: column;
+    gap: .5rem;
+}
+  .nav-menu.open {
+      display: flex;
+  }
 @media (max-width: 768px) {
     .app-header {
         padding: 0 calc(var(--page-side-padding) / 1.5);


### PR DESCRIPTION
## Summary
- Restyle header with light gray background and new layout sections
- Add flag-based language dropdown and right-aligned logo
- Introduce hamburger menu toggling navigation buttons

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689846c6a2a8832da9a60d22efc98726