### PR TITLE
Improve visual separation in production view

### DIFF
--- a/index.html
+++ b/index.html
@@ -413,19 +413,19 @@
             <div class="card">
                 <div class="card-header">
                     <h2 class="card-title" data-i18n="Produktionsliste">Produktionsliste</h2>
-                    <div class="production-controls">
-                        <input type="text" id="productionFilter" data-i18n-placeholder="Filter" placeholder="Filter">
-                        <select id="productionStatusFilter">
-                            <option value="all" data-i18n="Alle">Alle</option>
-                            <option value="pending" data-i18n="Offen">Offen</option>
-                            <option value="inProgress" data-i18n="In Arbeit">In Arbeit</option>
-                            <option value="done" data-i18n="Abgeschlossen">Abgeschlossen</option>
-                        </select>
-                        <select id="productionSort">
-                            <option value="startTime" data-i18n="Startzeit">Startzeit</option>
-                            <option value="projekt" data-i18n="Projekt">Projekt</option>
-                        </select>
-                    </div>
+                </div>
+                <div class="production-controls">
+                    <input type="text" id="productionFilter" data-i18n-placeholder="Filter" placeholder="Filter">
+                    <select id="productionStatusFilter">
+                        <option value="all" data-i18n="Alle">Alle</option>
+                        <option value="pending" data-i18n="Offen">Offen</option>
+                        <option value="inProgress" data-i18n="In Arbeit">In Arbeit</option>
+                        <option value="done" data-i18n="Abgeschlossen">Abgeschlossen</option>
+                    </select>
+                    <select id="productionSort">
+                        <option value="startTime" data-i18n="Startzeit">Startzeit</option>
+                        <option value="projekt" data-i18n="Projekt">Projekt</option>
+                    </select>
                 </div>
                 <ul id="productionList" class="production-list"></ul>
             </div>

--- a/styles.css
+++ b/styles.css
@@ -1191,6 +1191,9 @@ select {
     list-style: none;
     padding: 1rem;
     margin: 0;
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    background-color: var(--light-bg-color);
 }
 
 .production-item {
@@ -1203,6 +1206,11 @@ select {
     display: flex;
     gap: .5rem;
     flex-wrap: wrap;
+    padding: .75rem;
+    background-color: var(--light-bg-color);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    margin-bottom: 1rem;
 }
 
 .production-item.pending {


### PR DESCRIPTION
## Summary
- move production filter controls outside of header for clearer layout
- style controls and order list with borders, padding and light background to visually separate them

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689849277de4832db878b6ed9253f2e6