### PR TITLE
Deferrable start time and UI cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,10 +82,6 @@
                                 <input type="number" id="langdrahtDurchmesser" value="6" oninput="triggerPreviewUpdateDebounced(); validateNumberInput(this, 1, 'int', 'Längsdraht-Ø in mm (min. 1)');">
                                 <span class="input-feedback"></span>
                             </div>
-                            <div class="form-group">
-                                <label for="startzeit" data-i18n="Startzeitpunkt">Startzeitpunkt</label>
-                                <input type="datetime-local" id="startzeit" oninput="triggerPreviewUpdateDebounced()">
-                            </div>
                         </div>
                         <h3 class="section-title collapsible-header" data-i18n="PtGABBIE-Daten">PtGABBIE-Daten</h3>
                         <div class="collapsible-content section-content-bg">
@@ -263,44 +259,8 @@
                         </div>
                         <span id="copyFeedback" class="copy-feedback-text" style="text-align: right; display: block;"></span>
                     </div>
-                    <div class="card">
-                        <div class="card-header" style="display: flex; justify-content: space-between; align-items: center;">
-                            <h2 class="card-title" data-i18n="PDF417 Barcode">PDF417 Barcode</h2>
-                            <div style="font-size: .8rem; color: var(--text-muted-color);">
-                                <span data-i18n="Status:">Status:</span> <span id="barcodeStatus" data-i18n="Bereit">Bereit</span>
-                            </div>
-                        </div>
-                        <div id="barcodeSvgContainer"
-                            style="
-                            min-height: 120px;
-                            display: flex;
-                            flex-direction: column;
-                            justify-content: center;
-                            align-items: center;
-                            background-color: var(--light-bg-color);
-                            border-radius: var(--border-radius);
-                            padding: 1rem;
-                            ">
-                        </div>
-                        <div id="barcodeError" class="info-text" style="margin-top: .5rem; min-height: 1.2em;"></div>
-                        <details style="margin-top: 1rem; font-size: .8rem; color: var(--text-muted-color);">
-                            <summary style="cursor: pointer; user-select: none;" data-i18n="Debug-Informationen">Debug-Informationen</summary>
-                            <div id="barcodeDebugInfo"
-                                style="
-                                background-color: var(--light-bg-color);
-                                padding: .5rem;
-                                border-radius: var(--border-radius);
-                                margin-top: .5rem;
-                                font-family: monospace;
-                                white-space: pre-wrap;
-                                max-height: 200px;
-                                overflow-y: auto;
-                                font-size: .7rem;
-                                ">
-                            </div>
-                            <button type="button" class="btn-secondary" id="clearDebugLogButton" data-i18n="Debug-Log löschen">Debug-Log löschen</button>
-                        </details>
-                    </div>
+                    <div id="barcodeSvgContainer" class="hidden"></div>
+                    <div id="barcodeError" class="info-text" style="display:none;"></div>
                     <div class="card">
                         <div class="card-header" style="display: flex; justify-content: space-between; align-items: center;">
                             <h2 class="card-title" data-i18n="Druck-Label Vorschau">Druck-Label Vorschau</h2>
@@ -445,6 +405,30 @@
             <p style="font-size: .8rem; color: var(--text-muted-color);" data-i18n="Modern BVBS Korb Generator © 2025">Modern BVBS Korb Generator &copy; 2025</p>
         </footer>
         </div>
+        <div id="releaseModal" class="modal-overlay">
+            <div class="modal-content card">
+                <div class="modal-header card-header">
+                    <h2 class="modal-title card-title" data-i18n="Startzeitpunkt">Startzeitpunkt</h2>
+                    <button type="button" class="close-modal-btn" onclick="closeReleaseModal()">
+                        <svg viewBox="0 0 24 24">
+                            <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
+                        </svg>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <p class="info-text" data-i18n="Bitte Startzeitpunkt angeben.">Bitte Startzeitpunkt angeben.</p>
+                    <div class="form-group">
+                        <label for="releaseStartzeit" data-i18n="Startzeitpunkt">Startzeitpunkt</label>
+                        <input type="datetime-local" id="releaseStartzeit">
+                    </div>
+                    <div id="releaseModalError" class="info-text" style="min-height:1.2em;"></div>
+                    <div class="button-group" style="justify-content: flex-end; margin-top: 1rem;">
+                        <button type="button" id="confirmReleaseButton" class="btn-primary" data-i18n="Freigeben">Freigeben</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <div id="templateManagerModal" class="modal-overlay">
             <div class="modal-content card">
                 <div class="modal-header card-header">

--- a/production.js
+++ b/production.js
@@ -20,6 +20,16 @@ function showProductionView() {
     renderProductionList();
 }
 
+function openReleaseModal() {
+    const modal = document.getElementById('releaseModal');
+    if (modal) modal.classList.add('visible');
+}
+
+function closeReleaseModal() {
+    const modal = document.getElementById('releaseModal');
+    if (modal) modal.classList.remove('visible');
+}
+
 function statusKey(status) {
     switch (status) {
         case 'inProgress': return 'In Arbeit';
@@ -99,10 +109,20 @@ function renderProductionList() {
 document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('showGeneratorBtn')?.addEventListener('click', () => showGeneratorView());
     document.getElementById('showProductionBtn')?.addEventListener('click', () => showProductionView());
-    document.getElementById('releaseButton')?.addEventListener('click', async () => {
-        const startTime = document.getElementById('startzeit')?.value;
+    document.getElementById('releaseButton')?.addEventListener('click', () => {
+        const input = document.getElementById('releaseStartzeit');
+        if (input) {
+            input.value = new Date().toISOString().slice(0,16);
+        }
+        const err = document.getElementById('releaseModalError');
+        if (err) err.textContent = '';
+        openReleaseModal();
+    });
+
+    document.getElementById('confirmReleaseButton')?.addEventListener('click', async () => {
+        const startTime = document.getElementById('releaseStartzeit')?.value;
         if (!startTime) {
-            showFeedback('barcodeError', i18n.t('Bitte Startzeitpunkt angeben.'), 'warning', 3000);
+            showFeedback('releaseModalError', i18n.t('Bitte Startzeitpunkt angeben.'), 'warning', 3000);
             return;
         }
         const labelElement = document.getElementById('printableLabel');
@@ -117,6 +137,7 @@ document.addEventListener('DOMContentLoaded', () => {
             labelImg: imgData,
             status: 'pending'
         });
+        closeReleaseModal();
         renderProductionList();
         showProductionView();
     });

--- a/styles.css
+++ b/styles.css
@@ -710,6 +710,7 @@ select {
 
 .bvbs-output-field textarea {
     flex: 1;
+    height: 5rem;
 }
 			/* Damit das Canvas im Label immer maximal 100% breit ist */
                         #labelBarcodeContainer canvas,


### PR DESCRIPTION
## Summary
- Capture start time via a new release modal
- Remove the PDF417 barcode card and keep barcode generation hidden
- Increase BVBS code textarea height for better readability

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68988c6b8ee4832d908cffd67d3e6dbf