### PR TITLE
Add first stirrup and overhang toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,12 +179,18 @@
                     <div class="card preview-card">
                         <div class="card-header" style="display: flex; justify-content: space-between; align-items: center;">
                             <h2 class="card-title" style="margin-bottom: 0;" data-i18n="Visuelle Vorschau Korb">Visuelle Vorschau Korb</h2>
-                            <div id="dimensionModeToggleContainer">
-                                <label for="dimensioningToggle" data-i18n="Bemaßung Zonenlänge:">Bemaßung Zonenlänge:</label>
-                                <select id="dimensioningToggle" onchange="toggleDimensioningMode(this.value)">
-                                    <option value="arrangementLength" selected data-i18n="(n-1) x Pitch">(n-1) x Pitch</option>
-                                    <option value="totalZoneSpace" data-i18n="n x Pitch">n x Pitch</option>
-                                </select>
+                            <div style="display: flex; gap: 1rem; align-items: center;">
+                                <div id="overhangToggleContainer">
+                                    <label for="overhangToggle" data-i18n="Überstände anzeigen:">Überstände anzeigen:</label>
+                                    <input type="checkbox" id="overhangToggle" onchange="toggleOverhangVisibility(this.checked)">
+                                </div>
+                                <div id="dimensionModeToggleContainer">
+                                    <label for="dimensioningToggle" data-i18n="Bemaßung Zonenlänge:">Bemaßung Zonenlänge:</label>
+                                    <select id="dimensioningToggle" onchange="toggleDimensioningMode(this.value)">
+                                        <option value="arrangementLength" selected data-i18n="(n-1) x Pitch">(n-1) x Pitch</option>
+                                        <option value="totalZoneSpace" data-i18n="n x Pitch">n x Pitch</option>
+                                    </select>
+                                </div>
                             </div>
                         </div>
                         <div id="visualPreviewContainer">

--- a/lang/cz.json
+++ b/lang/cz.json
@@ -27,6 +27,7 @@
   "Jede Zone: Durchmesser, Anzahl, Pitch.": "Každá zóna: průměr, počet, rozteč.",
   "BVBS Code & Barcode generieren": "Generovat kód BVBS a čárový kód",
   "Visuelle Vorschau Korb": "Vizuální náhled koše",
+  "Überstände anzeigen:": "Zobrazit přesahy:",
   "Bemaßung Zonenlänge:": "Kótování délky zóny:",
   "(n-1) x Pitch": "(n-1) × rozteč",
   "n x Pitch": "n × rozteč",

--- a/lang/de.json
+++ b/lang/de.json
@@ -27,6 +27,7 @@
   "Jede Zone: Durchmesser, Anzahl, Pitch.": "Jede Zone: Durchmesser, Anzahl, Pitch.",
   "BVBS Code & Barcode generieren": "BVBS Code & Barcode generieren",
   "Visuelle Vorschau Korb": "Visuelle Vorschau Korb",
+  "Überstände anzeigen:": "Überstände anzeigen:",
   "Bemaßung Zonenlänge:": "Bemaßung Zonenlänge:",
   "(n-1) x Pitch": "(n-1) x Pitch",
   "n x Pitch": "n x Pitch",

--- a/lang/en.json
+++ b/lang/en.json
@@ -27,6 +27,7 @@
   "Jede Zone: Durchmesser, Anzahl, Pitch.": "Each Zone: Diameter, Quantity, Pitch.",
   "BVBS Code & Barcode generieren": "Generate BVBS Code & Barcode",
   "Visuelle Vorschau Korb": "Visual Cage Preview",
+  "Überstände anzeigen:": "Show overhangs:",
   "Bemaßung Zonenlänge:": "Dimensioning Zone Length:",
   "(n-1) x Pitch": "(n-1) x Pitch",
   "n x Pitch": "n x Pitch",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -27,6 +27,7 @@
   "Jede Zone: Durchmesser, Anzahl, Pitch.": "Każda strefa: średnica, liczba, rozstaw.",
   "BVBS Code & Barcode generieren": "Generuj kod BVBS i kod kreskowy",
   "Visuelle Vorschau Korb": "Wizualny podgląd kosza",
+  "Überstände anzeigen:": "Pokaż naddatki:",
   "Bemaßung Zonenlänge:": "Wymiarowanie długości strefy:",
   "(n-1) x Pitch": "(n-1) × rozstaw",
   "n x Pitch": "n × rozstaw",


### PR DESCRIPTION
## Summary
- ensure visual preview shows first stirrup at start in black
- add checkbox to show or hide start/end overhangs
- include translations for the new toggle

## Testing
- `node --check generator.js`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68988e6a145c832d965fcaf3501209e9