### PR TITLE
feat: add sidebar navigation with language and version

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,21 +24,36 @@
                     <h1 class="app-title" data-i18n="Modern BVBS Korb Generator (MEP)">BVBS Korb Generator (MEP)</h1>
                 </div>
                 <div class="right-section">
-                    <div class="language-select">
-                        <select id="languageSelect" onchange="setLanguage(this.value)">
-                            <option value="de">🇩🇪 DE</option>
-                            <option value="en">🇬🇧 EN</option>
-                            <option value="pl">🇵🇱 PL</option>
-                            <option value="cz">🇨🇿 CZ</option>
-                        </select>
-                    </div>
                     <div class="logo-area">
                         <img id="appLogo" src="./gb.png" alt="Firmenlogo">
                     </div>
                 </div>
                 <nav id="navMenu" class="nav-menu">
-                    <button id="showGeneratorBtn" class="btn-secondary" data-i18n="Generator">Generator</button>
-                    <button id="showProductionBtn" class="btn-secondary" data-i18n="Produktion">Produktion</button>
+                    <div class="nav-menu-items">
+                        <button id="showGeneratorBtn">
+                            <svg viewBox="0 0 24 24">
+                                <path d="M11 21h-1l1-7H5.6L13 3h1l-1 7h6.5L11 21z" />
+                            </svg>
+                            <span data-i18n="Generator">Generator</span>
+                        </button>
+                        <button id="showProductionBtn">
+                            <svg viewBox="0 0 24 24">
+                                <path d="M3 3h18v2H3V3zm0 7h18v2H3v-2zm0 7h18v2H3v-2z" />
+                            </svg>
+                            <span data-i18n="Produktion">Produktion</span>
+                        </button>
+                    </div>
+                    <div class="nav-menu-bottom">
+                        <div class="language-select">
+                            <select id="languageSelect" onchange="setLanguage(this.value)">
+                                <option value="de">🇩🇪 DE</option>
+                                <option value="en">🇬🇧 EN</option>
+                                <option value="pl">🇵🇱 PL</option>
+                                <option value="cz">🇨🇿 CZ</option>
+                            </select>
+                        </div>
+                        <div class="app-version">v1.0.0</div>
+                    </div>
                 </nav>
             </header>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -318,8 +318,8 @@ select {
 }
 .language-select select {
     background-color: transparent;
-    color: var(--header-text-color);
-    border: 1px solid var(--header-text-color);
+    color: var(--text-color);
+    border: 1px solid var(--border-color);
 }
 
 .burger-menu {
@@ -336,20 +336,50 @@ select {
     fill: var(--header-text-color);
 }
 .nav-menu {
-    position: absolute;
-    top: 55px;
+    position: fixed;
+    top: 0;
+    bottom: 0;
     left: 0;
-    right: 0;
+    width: 220px;
     background: #f0f0f0;
     box-shadow: var(--shadow-md);
     padding: 1rem;
-    display: none;
+    display: flex;
+    flex-direction: column;
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+    z-index: 1000;
+}
+.nav-menu.open {
+    transform: translateX(0);
+}
+.nav-menu-items {
+    display: flex;
     flex-direction: column;
     gap: .5rem;
 }
-  .nav-menu.open {
-      display: flex;
-  }
+.nav-menu button {
+    background: none;
+    border: none;
+    color: var(--text-color);
+    padding: .5rem;
+    text-align: left;
+    display: flex;
+    align-items: center;
+    gap: .5rem;
+    cursor: pointer;
+}
+.nav-menu button:hover {
+    background-color: var(--light-bg-color);
+}
+.nav-menu-bottom {
+    margin-top: auto;
+}
+.nav-menu .app-version {
+    font-size: .75rem;
+    opacity: 0.6;
+    margin-top: 0.5rem;
+}
 @media (max-width: 768px) {
     .app-header {
         padding: 0 calc(var(--page-side-padding) / 1.5);


### PR DESCRIPTION
## Summary
- replace dropdown nav with left sidebar including icons
- move language selector into sidebar and show version number

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689893bcedc4832daabbe367888c68cc