### PR TITLE
feat: add collapsible sidebar

### DIFF
--- a/production.js
+++ b/production.js
@@ -155,12 +155,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     document.getElementById('burgerMenu')?.addEventListener('click', () => {
-        document.getElementById('navMenu')?.classList.toggle('open');
-    });
-    document.querySelectorAll('#navMenu button').forEach(btn => {
-        btn.addEventListener('click', () => {
-            document.getElementById('navMenu')?.classList.remove('open');
-        });
+        document.body.classList.toggle('sidebar-open');
     });
     showGeneratorView();
 });

--- a/styles.css
+++ b/styles.css
@@ -34,6 +34,9 @@
     --page-content-max-pixel-width: 1600px;
     --page-side-padding: 2rem;
 
+    /* Sidebar */
+    --sidebar-width: 60px;
+
     /* SVG Zone Colors */
     --svg-zone-color-0: #4A90E2;
     --svg-zone-color-1: #363a39;
@@ -222,6 +225,8 @@ select {
     top: 0;
     z-index: 1000;
     box-sizing: border-box;
+    padding-left: var(--sidebar-width);
+    transition: padding-left 0.3s ease;
 }
 .app-header {
     width: var(--page-content-width);
@@ -306,6 +311,10 @@ select {
 .app-header, .app-container {
     width: 95vw;
 }
+.app-container {
+    padding-left: calc(var(--sidebar-width) + var(--page-side-padding));
+    transition: padding-left 0.3s ease;
+}
 .app-header .btn-secondary {
     background-color: transparent;
     border: 1px solid var(--header-text-color);
@@ -335,23 +344,24 @@ select {
     height: 24px;
     fill: var(--header-text-color);
 }
+
+body.sidebar-open {
+    --sidebar-width: 220px;
+}
 .nav-menu {
     position: fixed;
     top: 0;
     bottom: 0;
     left: 0;
-    width: 220px;
+    width: var(--sidebar-width);
     background: #f0f0f0;
     box-shadow: var(--shadow-md);
     padding: 1rem;
     display: flex;
     flex-direction: column;
-    transform: translateX(-100%);
-    transition: transform 0.3s ease;
+    transition: width 0.3s ease;
     z-index: 1000;
-}
-.nav-menu.open {
-    transform: translateX(0);
+    overflow: hidden;
 }
 .nav-menu-items {
     display: flex;
@@ -368,6 +378,18 @@ select {
     align-items: center;
     gap: .5rem;
     cursor: pointer;
+    justify-content: center;
+}
+.nav-menu span,
+.nav-menu-bottom {
+    display: none;
+}
+body.sidebar-open .nav-menu button {
+    justify-content: flex-start;
+}
+body.sidebar-open .nav-menu span,
+body.sidebar-open .nav-menu-bottom {
+    display: block;
 }
 .nav-menu button:hover {
     background-color: var(--light-bg-color);
@@ -386,6 +408,7 @@ select {
     }
     .app-container {
         padding: 0 calc(var(--page-side-padding) / 1.5);
+        padding-left: calc(var(--sidebar-width) + var(--page-side-padding) / 1.5);
     }
     .app-header .app-title {
         font-size: 1rem;


### PR DESCRIPTION
## Summary
- allow collapsing the sidebar to icon-only or expanded modes
- toggle sidebar state via burger menu by adding a body class

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689896ce86a4832dba8c889b47c474a7