### PR TITLE
Render sidebar below header

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,35 +28,35 @@
                         <img id="appLogo" src="./gb.png" alt="Firmenlogo">
                     </div>
                 </div>
-                <nav id="navMenu" class="nav-menu">
-                    <div class="nav-menu-items">
-                        <button id="showGeneratorBtn">
-                            <svg viewBox="0 0 24 24">
-                                <path d="M11 21h-1l1-7H5.6L13 3h1l-1 7h6.5L11 21z" />
-                            </svg>
-                            <span data-i18n="Generator">Generator</span>
-                        </button>
-                        <button id="showProductionBtn">
-                            <svg viewBox="0 0 24 24">
-                                <path d="M3 3h18v2H3V3zm0 7h18v2H3v-2zm0 7h18v2H3v-2z" />
-                            </svg>
-                            <span data-i18n="Produktion">Produktion</span>
-                        </button>
-                    </div>
-                    <div class="nav-menu-bottom">
-                        <div class="language-select">
-                            <select id="languageSelect" onchange="setLanguage(this.value)">
-                                <option value="de">🇩🇪 DE</option>
-                                <option value="en">🇬🇧 EN</option>
-                                <option value="pl">🇵🇱 PL</option>
-                                <option value="cz">🇨🇿 CZ</option>
-                            </select>
-                        </div>
-                        <div class="app-version">v1.0.0</div>
-                    </div>
-                </nav>
             </header>
         </div>
+        <nav id="navMenu" class="nav-menu">
+            <div class="nav-menu-items">
+                <button id="showGeneratorBtn">
+                    <svg viewBox="0 0 24 24">
+                        <path d="M11 21h-1l1-7H5.6L13 3h1l-1 7h6.5L11 21z" />
+                    </svg>
+                    <span data-i18n="Generator">Generator</span>
+                </button>
+                <button id="showProductionBtn">
+                    <svg viewBox="0 0 24 24">
+                        <path d="M3 3h18v2H3V3zm0 7h18v2H3v-2zm0 7h18v2H3v-2z" />
+                    </svg>
+                    <span data-i18n="Produktion">Produktion</span>
+                </button>
+            </div>
+            <div class="nav-menu-bottom">
+                <div class="language-select">
+                    <select id="languageSelect" onchange="setLanguage(this.value)">
+                        <option value="de">🇩🇪 DE</option>
+                        <option value="en">🇬🇧 EN</option>
+                        <option value="pl">🇵🇱 PL</option>
+                        <option value="cz">🇨🇿 CZ</option>
+                    </select>
+                </div>
+                <div class="app-version">v1.0.0</div>
+            </div>
+        </nav>
         <div id="generatorView" class="app-container">
             <div class="main-grid">
                 <div class="input-column card">

--- a/styles.css
+++ b/styles.css
@@ -33,6 +33,7 @@
     --page-content-width: 95vw;
     --page-content-max-pixel-width: 1600px;
     --page-side-padding: 2rem;
+    --header-height: 55px;
 
     /* Sidebar */
     --sidebar-width: 60px;
@@ -225,8 +226,6 @@ select {
     top: 0;
     z-index: 1000;
     box-sizing: border-box;
-    padding-left: var(--sidebar-width);
-    transition: padding-left 0.3s ease;
 }
 .app-header {
     width: var(--page-content-width);
@@ -235,7 +234,7 @@ select {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    height: 55px;
+    height: var(--header-height);
     padding: 0 var(--page-side-padding);
     box-sizing: border-box;
     position: relative;
@@ -350,7 +349,7 @@ body.sidebar-open {
 }
 .nav-menu {
     position: fixed;
-    top: 0;
+    top: var(--header-height);
     bottom: 0;
     left: 0;
     width: var(--sidebar-width);


### PR DESCRIPTION
## Summary
- Move navigation menu outside the header so the sidebar opens below the header
- Add `--header-height` CSS variable and use it to place the sidebar; remove header padding

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898a475cc8c832dae63912e78aea5dc