### PR TITLE
Use SVG icons for language selector

### DIFF
--- a/flags/cz.svg
+++ b/flags/cz.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 3 2">
+  <rect width="3" height="2" fill="#fff"/>
+  <rect width="3" height="1" y="1" fill="#D7141A"/>
+  <polygon points="0,0 1.5,1 0,2" fill="#11457E"/>
+</svg>

--- a/flags/de.svg
+++ b/flags/de.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 5 3">
+  <rect width="5" height="1" y="0" fill="#000"/>
+  <rect width="5" height="1" y="1" fill="#DD0000"/>
+  <rect width="5" height="1" y="2" fill="#FFCE00"/>
+</svg>

--- a/flags/gb.svg
+++ b/flags/gb.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 30">
+  <rect width="60" height="30" fill="#012169"/>
+  <path d="M0,0 60,30 M60,0 0,30" stroke="#fff" stroke-width="6"/>
+  <path d="M0,0 60,30 M60,0 0,30" stroke="#C8102E" stroke-width="4"/>
+  <path d="M30,0 v30 M0,15 h60" stroke="#fff" stroke-width="10"/>
+  <path d="M30,0 v30 M0,15 h60" stroke="#C8102E" stroke-width="6"/>
+</svg>

--- a/flags/pl.svg
+++ b/flags/pl.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 5 3">
+  <rect width="5" height="3" fill="#fff"/>
+  <rect width="5" height="1.5" y="1.5" fill="#D4213D"/>
+</svg>

--- a/i18n.js
+++ b/i18n.js
@@ -3,7 +3,17 @@
 let translations = {};
 // Die aktuelle Sprache wird aus dem localStorage geladen oder auf 'de' als Standard gesetzt.
 // Dies ist wichtig für den Initialzustand und falls keine Sprache explizit gesetzt wurde.
-let currentLang = localStorage.getItem("language") || "de"; 
+let currentLang = localStorage.getItem("language") || "de";
+
+function updateLanguageFlag() {
+    const select = document.getElementById("languageSelect");
+    if (!select) return;
+    const option = select.options[select.selectedIndex];
+    const flag = option.getAttribute("data-flag");
+    if (flag) {
+        select.style.backgroundImage = `url(${flag})`;
+    }
+}
 
 /**
  * Helferfunktion zum Abrufen von Übersetzungen im JavaScript-Code.
@@ -80,6 +90,7 @@ async function loadLanguage(lang) {
         const select = document.getElementById("languageSelect");
         if (select) {
             select.value = lang;
+            updateLanguageFlag();
         }
 
         // !!! WICHTIG !!!
@@ -157,6 +168,12 @@ document.addEventListener("DOMContentLoaded", () => {
     // Wenn keine Sprache gespeichert ist, verwende Deutsch ('de') als Standard.
     const lang = localStorage.getItem("language") || "de";
     loadLanguage(lang); // Lade die entsprechende Sprachdatei.
+
+    const languageSelect = document.getElementById('languageSelect');
+    if (languageSelect) {
+        languageSelect.addEventListener('change', updateLanguageFlag);
+        updateLanguageFlag();
+    }
 
     // Dies ist ein spezieller Fall, falls das placeholder-Attribut nicht direkt
     // über data-i18n-placeholder im HTML gesetzt ist oder dynamisch initialisiert werden muss.

--- a/index.html
+++ b/index.html
@@ -48,10 +48,10 @@
             <div class="nav-menu-bottom">
                 <div class="language-select">
                     <select id="languageSelect" onchange="setLanguage(this.value)">
-                        <option value="de">🇩🇪 DE</option>
-                        <option value="en">🇬🇧 EN</option>
-                        <option value="pl">🇵🇱 PL</option>
-                        <option value="cz">🇨🇿 CZ</option>
+                        <option value="de" data-flag="flags/de.svg">DE</option>
+                        <option value="en" data-flag="flags/gb.svg">EN</option>
+                        <option value="pl" data-flag="flags/pl.svg">PL</option>
+                        <option value="cz" data-flag="flags/cz.svg">CZ</option>
                     </select>
                 </div>
                 <div class="app-version">v1.0.0</div>

--- a/styles.css
+++ b/styles.css
@@ -328,7 +328,23 @@ select {
     background-color: transparent;
     color: var(--text-color);
     border: 1px solid var(--border-color);
+    padding-left: 2rem;
+    background-repeat: no-repeat;
+    background-position: .3rem center;
+    background-size: 1.5rem auto;
 }
+
+.language-select option {
+    padding-left: 2rem;
+    background-repeat: no-repeat;
+    background-position: .3rem center;
+    background-size: 1.5rem auto;
+}
+
+.language-select option[value="de"] { background-image: url('flags/de.svg'); }
+.language-select option[value="en"] { background-image: url('flags/gb.svg'); }
+.language-select option[value="pl"] { background-image: url('flags/pl.svg'); }
+.language-select option[value="cz"] { background-image: url('flags/cz.svg'); }
 
 .burger-menu {
     background: none;


### PR DESCRIPTION
## Summary
- Replace emoji flags in language dropdown with SVG icons
- Style select and options to display flag images
- Update language script to show appropriate flag for chosen language

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898a87fbc54832d82954e5eb9e318e6