### PR TITLE
Replace burger menu with bottom sidebar toggle and refine language dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,11 +16,6 @@
         <div class="app-header-wrapper">
             <header class="app-header">
                 <div class="left-section">
-                    <button id="burgerMenu" class="burger-menu" aria-label="Menü">
-                        <svg viewBox="0 0 24 24">
-                            <path d="M3 6h18v2H3V6zm0 5h18v2H3v-2zm0 5h18v2H3v-2z" />
-                        </svg>
-                    </button>
                     <h1 class="app-title" data-i18n="Modern BVBS Korb Generator (MEP)">BVBS Korb Generator (MEP)</h1>
                 </div>
                 <div class="right-section">
@@ -55,6 +50,7 @@
                     </select>
                 </div>
                 <div class="app-version">v1.0.0</div>
+                <button id="sidebarToggle" class="sidebar-toggle" aria-label="Sidebar umschalten">&gt;</button>
             </div>
         </nav>
         <div id="generatorView" class="app-container">

--- a/production.js
+++ b/production.js
@@ -166,9 +166,14 @@ document.addEventListener('DOMContentLoaded', () => {
         renderProductionList();
     });
 
-    document.getElementById('burgerMenu')?.addEventListener('click', () => {
-        document.body.classList.toggle('sidebar-open');
-    });
+    const sidebarToggle = document.getElementById('sidebarToggle');
+    if (sidebarToggle) {
+        sidebarToggle.textContent = document.body.classList.contains('sidebar-open') ? '<' : '>';
+        sidebarToggle.addEventListener('click', () => {
+            document.body.classList.toggle('sidebar-open');
+            sidebarToggle.textContent = document.body.classList.contains('sidebar-open') ? '<' : '>';
+        });
+    }
     setInterval(() => {
         if (productionList.some(p => p.status === 'inProgress')) {
             renderProductionList();

--- a/styles.css
+++ b/styles.css
@@ -324,21 +324,29 @@ select {
     border-color: var(--header-text-color);
     color: var(--header-text-color);
 }
+.language-select {
+    display: flex;
+    justify-content: center;
+}
+
 .language-select select {
     background-color: transparent;
     color: var(--text-color);
     border: 1px solid var(--border-color);
-    padding-left: 2rem;
+    padding: .25rem .5rem .25rem 1.8rem;
     background-repeat: no-repeat;
     background-position: .3rem center;
-    background-size: 1.5rem auto;
+    background-size: 1.2rem auto;
+    font-size: .875rem;
+    width: 100%;
+    max-width: 120px;
 }
 
 .language-select option {
-    padding-left: 2rem;
+    padding-left: 1.8rem;
     background-repeat: no-repeat;
     background-position: .3rem center;
-    background-size: 1.5rem auto;
+    background-size: 1.2rem auto;
 }
 
 .language-select option[value="de"] { background-image: url('flags/de.svg'); }
@@ -346,18 +354,16 @@ select {
 .language-select option[value="pl"] { background-image: url('flags/pl.svg'); }
 .language-select option[value="cz"] { background-image: url('flags/cz.svg'); }
 
-.burger-menu {
+.sidebar-toggle {
     background: none;
     border: none;
     cursor: pointer;
-    padding: .25rem;
+    padding: .5rem;
     display: flex;
     align-items: center;
-}
-.burger-menu svg {
-    width: 24px;
-    height: 24px;
-    fill: var(--header-text-color);
+    justify-content: center;
+    font-size: 1.25rem;
+    color: var(--text-color);
 }
 
 body.sidebar-open {
@@ -396,14 +402,16 @@ body.sidebar-open {
     justify-content: center;
 }
 .nav-menu span,
-.nav-menu-bottom {
+.nav-menu-bottom .language-select,
+.nav-menu-bottom .app-version {
     display: none;
 }
 body.sidebar-open .nav-menu button {
     justify-content: flex-start;
 }
 body.sidebar-open .nav-menu span,
-body.sidebar-open .nav-menu-bottom {
+body.sidebar-open .nav-menu-bottom .language-select,
+body.sidebar-open .nav-menu-bottom .app-version {
     display: block;
 }
 .nav-menu button:hover {
@@ -411,6 +419,10 @@ body.sidebar-open .nav-menu-bottom {
 }
 .nav-menu-bottom {
     margin-top: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: .5rem;
 }
 .nav-menu .app-version {
     font-size: .75rem;


### PR DESCRIPTION
## Summary
- Remove header burger menu and add bottom sidebar toggle control.
- Style language selector as compact flag-text dropdown positioned above version.
- Update scripts to control sidebar with new arrow toggle.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898aadef5dc832dab2a50479f92ddba