### PR TITLE
Fix language switch and first zone preview

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -1,6 +1,10 @@
-			let zonesData = [];
-			let templates = [];
-			let nextZoneId = 0;
+let zonesData = [];
+let templates = [];
+let nextZoneId = 0;
+
+function getEffectiveZoneNum(zone, index) {
+    return index === 0 ? zone.num + 1 : zone.num;
+}
 			
 			// Visual constants for SVG rendering
 			const STIRRUP_HEIGHT_VISUAL = 50;
@@ -473,15 +477,16 @@ function loadLabelLayout() {
 			    if (!zones || zones.length === 0) {
 			        return "Keine Zonen definiert.";
 			    }
-			    const summary = zones.map(zone => {
-			        if (zone.num === 1) {
-			            return `Ø${zone.dia}(1x)`;
-			        } else if (zone.num > 1) {
-			            return `Ø${zone.dia}(${zone.num}x${zone.pitch})`;
-			        } else {
-			            return `Ø${zone.dia}(0x)`;
-			        }
-			    });
+                            const summary = zones.map((zone, idx) => {
+                                const effectiveNum = getEffectiveZoneNum(zone, idx);
+                                if (effectiveNum === 1) {
+                                    return `Ø${zone.dia}(1x)`;
+                                } else if (effectiveNum > 1) {
+                                    return `Ø${zone.dia}(${effectiveNum}x${zone.pitch})`;
+                                } else {
+                                    return `Ø${zone.dia}(0x)`;
+                                }
+                            });
 			    return `${zones.length} Zone(n): ${summary.join(', ')}`;
 			}
 			
@@ -900,7 +905,7 @@ function updateZonesPerLabel(value) {
                                 if (colIndex === 0) {
                                     zonesData.forEach((zone, index) => values.push(index + 1));
                                 } else if (colIndex === 1) {
-                                    zonesData.forEach(zone => values.push(zone.num));
+                                    zonesData.forEach((zone, i) => values.push(getEffectiveZoneNum(zone, i)));
                                 } else {
                                     zonesData.forEach(zone => values.push(zone.pitch));
                                 }
@@ -1052,7 +1057,7 @@ function updateZonesPerLabel(value) {
                                 zonesData.forEach((zone, index) => {
                                     const zoneStart = currentPositionMm;
                                     const displayIndex = index + 1;
-                                    const numStirrups = zone.num;
+                                    const numStirrups = getEffectiveZoneNum(zone, index);
                                     const pitch = zone.pitch;
                                     const dia = zone.dia;
 
@@ -1285,7 +1290,10 @@ function updateZonesPerLabel(value) {
                                     let pt = "PtGABBIE;";
                                     pt += `i${startOv};`;
                                     pt += `f${endOv};`;
-                                    zonesArr.forEach(z => { pt += `d${z.dia};n${z.num};p${z.pitch};`; });
+                                    zonesArr.forEach((z, idx) => {
+                                        const effectiveNum = getEffectiveZoneNum(z, idx);
+                                        pt += `d${z.dia};n${effectiveNum};p${z.pitch};`;
+                                    });
                                     if (name) pt += `s${name};`;
                                     if (rezeptname) pt += `r${rezeptname};`;
                                     if (pt.endsWith(';')) pt = pt.slice(0,-1);

--- a/i18n.js
+++ b/i18n.js
@@ -92,6 +92,7 @@ async function loadLanguage(lang) {
             select.value = lang;
             updateLanguageFlag();
         }
+        document.documentElement.lang = lang;
 
         // !!! WICHTIG !!!
         // Nach dem Laden einer neuen Sprache müssen alle Funktionen, die dynamische
@@ -171,7 +172,10 @@ document.addEventListener("DOMContentLoaded", () => {
 
     const languageSelect = document.getElementById('languageSelect');
     if (languageSelect) {
-        languageSelect.addEventListener('change', updateLanguageFlag);
+        languageSelect.addEventListener('change', (e) => {
+            setLanguage(e.target.value);
+            updateLanguageFlag();
+        });
         updateLanguageFlag();
     }
 

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
             </div>
             <div class="nav-menu-bottom">
                 <div class="language-select">
-                    <select id="languageSelect" onchange="setLanguage(this.value)">
+                    <select id="languageSelect">
                         <option value="de" data-flag="flags/de.svg">DE</option>
                         <option value="en" data-flag="flags/gb.svg">EN</option>
                         <option value="pl" data-flag="flags/pl.svg">PL</option>


### PR DESCRIPTION
## Summary
- handle language selection via JS event and update page lang attribute
- ensure first zone renders default stirrup and correct counts

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898acaab580832db881891ad41f7ee4