### PR TITLE
Allow adding notes to orders

### DIFF
--- a/index.html
+++ b/index.html
@@ -438,6 +438,10 @@
                         <label for="releaseStartzeit" data-i18n="Startzeitpunkt">Startzeitpunkt</label>
                         <input type="datetime-local" id="releaseStartzeit">
                     </div>
+                    <div class="form-group">
+                        <label for="releaseNote" data-i18n="Bemerkung">Bemerkung</label>
+                        <input type="text" id="releaseNote">
+                    </div>
                     <div id="releaseModalError" class="info-text" style="min-height:1.2em;"></div>
                     <div class="button-group" style="justify-content: flex-end; margin-top: 1rem;">
                         <button type="button" id="confirmReleaseButton" class="btn-primary" data-i18n="Freigeben">Freigeben</button>

--- a/lang/cz.json
+++ b/lang/cz.json
@@ -153,5 +153,6 @@
   "Startzeit": "Čas startu",
   "Projekt": "Projekt",
   "Bitte Startzeitpunkt angeben.": "Zadejte čas startu.",
-  "Laufzeit": "Doba trvání"
+  "Laufzeit": "Doba trvání",
+  "Bemerkung": "Poznámka"
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -153,5 +153,6 @@
   "Startzeit": "Startzeit",
   "Projekt": "Projekt",
   "Bitte Startzeitpunkt angeben.": "Bitte Startzeitpunkt angeben.",
-  "Laufzeit": "Laufzeit"
+  "Laufzeit": "Laufzeit",
+  "Bemerkung": "Bemerkung"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -153,5 +153,6 @@
   "Startzeit": "Start Time",
   "Projekt": "Project",
   "Bitte Startzeitpunkt angeben.": "Please provide start time.",
-  "Laufzeit": "Elapsed Time"
+  "Laufzeit": "Elapsed Time",
+  "Bemerkung": "Note"
 }

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -153,5 +153,6 @@
   "Startzeit": "Czas startu",
   "Projekt": "Projekt",
   "Bitte Startzeitpunkt angeben.": "Podaj czas startu.",
-  "Laufzeit": "Czas trwania"
+  "Laufzeit": "Czas trwania",
+  "Bemerkung": "Notatka"
 }

--- a/production.js
+++ b/production.js
@@ -80,6 +80,7 @@ function renderProductionList() {
                         <div><strong>Komm:</strong> ${item.komm}</div>
                         <div><strong>${i18n.t('Auftrag')}:</strong> ${item.auftrag}</div>
                         <div><strong>Pos-Nr:</strong> ${item.posnr}</div>
+                        <div><strong>${i18n.t('Bemerkung')}:</strong> ${item.note || ''}</div>
                         ${duration !== null ? `<div><strong>${i18n.t('Laufzeit')}:</strong> ${formatDuration(duration)}</div>` : ''}
                         <div><strong>${i18n.t('Status')}:</strong> ${i18n.t(statusKey(item.status))}</div>`;
         const img = document.createElement('img');
@@ -91,6 +92,17 @@ function renderProductionList() {
         li.appendChild(img);
         const btnGroup = document.createElement('div');
         btnGroup.className = 'button-group';
+        const noteBtn = document.createElement('button');
+        noteBtn.className = 'btn-secondary';
+        noteBtn.textContent = i18n.t('Bemerkung');
+        noteBtn.addEventListener('click', () => {
+            const newNote = prompt(i18n.t('Bemerkung'), item.note || '');
+            if (newNote !== null) {
+                item.note = newNote;
+                renderProductionList();
+            }
+        });
+        btnGroup.appendChild(noteBtn);
         if (item.status === 'pending') {
             const startBtn = document.createElement('button');
             startBtn.className = 'btn-secondary';
@@ -126,6 +138,8 @@ document.addEventListener('DOMContentLoaded', () => {
         if (input) {
             input.value = new Date().toISOString().slice(0,16);
         }
+        const note = document.getElementById('releaseNote');
+        if (note) note.value = '';
         const err = document.getElementById('releaseModalError');
         if (err) err.textContent = '';
         openReleaseModal();
@@ -146,6 +160,7 @@ document.addEventListener('DOMContentLoaded', () => {
             komm: document.getElementById('KommNr').value,
             auftrag: document.getElementById('auftrag').value,
             posnr: document.getElementById('posnr').value,
+            note: document.getElementById('releaseNote')?.value || '',
             labelImg: imgData,
             status: 'pending'
         });


### PR DESCRIPTION
## Summary
- Add note input to release modal so each order can include a remark
- Display and edit order notes in production list
- Localize note label across languages

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898b8d9fd28832d9d69da08d2fda405