### PR TITLE
Enable saving orders before production release

### DIFF
--- a/index.html
+++ b/index.html
@@ -390,6 +390,8 @@
                             </div>
                         </div>
                         <div class="button-group" style="justify-content: flex-end; margin-top: 1rem;">
+                            <button type="button" id="openSavedOrdersButton" class="btn-secondary" data-i18n="Gespeicherte Aufträge">Gespeicherte Aufträge</button>
+                            <button type="button" id="saveOrderButton" class="btn-secondary" data-i18n="Auftrag speichern">Auftrag speichern</button>
                             <button type="button" id="releaseButton" class="btn-primary" data-i18n="Freigeben">Freigeben</button>
                         </div>
                         </div>
@@ -446,6 +448,25 @@
                     <div class="button-group" style="justify-content: flex-end; margin-top: 1rem;">
                         <button type="button" id="confirmReleaseButton" class="btn-primary" data-i18n="Freigeben">Freigeben</button>
                     </div>
+                </div>
+            </div>
+        </div>
+
+        <div id="savedOrdersModal" class="modal-overlay">
+            <div class="modal-content card">
+                <div class="modal-header card-header">
+                    <h2 class="modal-title card-title" data-i18n="Gespeicherte Aufträge">Gespeicherte Aufträge</h2>
+                    <button type="button" class="close-modal-btn" onclick="closeSavedOrdersModal()">
+                        <svg viewBox="0 0 24 24">
+                            <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
+                        </svg>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <ul id="savedOrdersList" class="production-list"></ul>
+                </div>
+                <div class="modal-footer button-group" style="justify-content: flex-end;">
+                    <button type="button" class="btn-secondary" onclick="closeSavedOrdersModal()" data-i18n="Schließen">Schließen</button>
                 </div>
             </div>
         </div>

--- a/lang/cz.json
+++ b/lang/cz.json
@@ -157,5 +157,11 @@
   "Bemerkung": "Poznámka",
   "Bearbeiten": "Upravit",
   "Passwort eingeben": "Zadejte heslo",
-  "Falsches Passwort": "Špatné heslo"
+  "Falsches Passwort": "Špatné heslo",
+  "Auftrag speichern": "Uložit zakázku",
+  "Gespeicherte Aufträge": "Uložené zakázky",
+  "Laden": "Načíst",
+  "Löschen": "Smazat",
+  "Keine Aufträge gespeichert.": "Žádné uložené zakázky.",
+  "Auftrag gespeichert.": "Zakázka uložena."
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -157,5 +157,11 @@
   "Bemerkung": "Bemerkung",
   "Bearbeiten": "Bearbeiten",
   "Passwort eingeben": "Passwort eingeben",
-  "Falsches Passwort": "Falsches Passwort"
+  "Falsches Passwort": "Falsches Passwort",
+  "Auftrag speichern": "Auftrag speichern",
+  "Gespeicherte Aufträge": "Gespeicherte Aufträge",
+  "Laden": "Laden",
+  "Löschen": "Löschen",
+  "Keine Aufträge gespeichert.": "Keine Aufträge gespeichert.",
+  "Auftrag gespeichert.": "Auftrag gespeichert."
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -157,5 +157,11 @@
   "Bemerkung": "Note",
   "Bearbeiten": "Edit",
   "Passwort eingeben": "Enter password",
-  "Falsches Passwort": "Wrong password"
+  "Falsches Passwort": "Wrong password",
+  "Auftrag speichern": "Save order",
+  "Gespeicherte Aufträge": "Saved orders",
+  "Laden": "Load",
+  "Löschen": "Delete",
+  "Keine Aufträge gespeichert.": "No orders saved.",
+  "Auftrag gespeichert.": "Order saved."
 }

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -157,5 +157,11 @@
   "Bemerkung": "Notatka",
   "Bearbeiten": "Edytuj",
   "Passwort eingeben": "Wprowadź hasło",
-  "Falsches Passwort": "Nieprawidłowe hasło"
+  "Falsches Passwort": "Nieprawidłowe hasło",
+  "Auftrag speichern": "Zapisz zlecenie",
+  "Gespeicherte Aufträge": "Zapisane zlecenia",
+  "Laden": "Wczytaj",
+  "Löschen": "Usuń",
+  "Keine Aufträge gespeichert.": "Brak zapisanych zleceń.",
+  "Auftrag gespeichert.": "Zlecenie zapisane."
 }

--- a/production.js
+++ b/production.js
@@ -189,6 +189,9 @@ document.addEventListener('DOMContentLoaded', () => {
             labelImg: imgData,
             status: 'pending'
         });
+        if (window.deleteCurrentSavedOrder) {
+            window.deleteCurrentSavedOrder();
+        }
         closeReleaseModal();
         renderProductionList();
         showProductionView();


### PR DESCRIPTION
## Summary
- add buttons and modal to save and reopen orders prior to production release
- persist draft orders in localStorage with list, load and delete helpers
- clean up saved draft after releasing to production and localize new UI strings

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898d7e1e4fc832d9c0862fff3cea5d0