### PR TITLE
refactor: use tailwind css for layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,55 +5,47 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title data-i18n="BVBS Korb Generator mit Label-Druck">BVBS Korb Generator mit Label-Druck</title>
         <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+        <script src="https://cdn.tailwindcss.com"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/bwip-js/3.2.0/bwip-js.min.js"></script>
         <link rel="stylesheet" href="styles.css">
         <script src="i18n.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
-                <script src="generator.js" defer></script>
+        <script src="generator.js" defer></script>
         <script src="production.js" defer></script>
     </head>
-    <body>
-        <div class="app-header-wrapper">
-            <header class="app-header">
-                <div class="left-section">
-                    <h1 class="app-title" data-i18n="Modern BVBS Korb Generator (MEP)">BVBS Korb Generator (MEP)</h1>
-                </div>
-                <div class="right-section">
-                    <div class="logo-area">
-                        <img id="appLogo" src="./gb.png" alt="Firmenlogo">
-                    </div>
-                </div>
-            </header>
-        </div>
-        <nav id="navMenu" class="nav-menu">
-            <div class="nav-menu-items">
-                <button id="showGeneratorBtn">
-                    <svg viewBox="0 0 24 24">
+    <body class="min-h-screen flex">
+        <nav id="navMenu" class="flex flex-col justify-between w-64 bg-gray-800 text-gray-100 p-4">
+            <div class="space-y-2">
+                <button id="showGeneratorBtn" class="flex items-center w-full px-3 py-2 rounded hover:bg-gray-700">
+                    <svg class="w-5 h-5 mr-2" viewBox="0 0 24 24">
                         <path d="M11 21h-1l1-7H5.6L13 3h1l-1 7h6.5L11 21z" />
                     </svg>
                     <span data-i18n="Generator">Generator</span>
                 </button>
-                <button id="showProductionBtn">
-                    <svg viewBox="0 0 24 24">
+                <button id="showProductionBtn" class="flex items-center w-full px-3 py-2 rounded hover:bg-gray-700">
+                    <svg class="w-5 h-5 mr-2" viewBox="0 0 24 24">
                         <path d="M3 3h18v2H3V3zm0 7h18v2H3v-2zm0 7h18v2H3v-2z" />
                     </svg>
                     <span data-i18n="Produktion">Produktion</span>
                 </button>
             </div>
-            <div class="nav-menu-bottom">
-                <div class="language-select">
-                    <select id="languageSelect">
-                        <option value="de" data-flag="flags/de.svg">DE</option>
-                        <option value="en" data-flag="flags/gb.svg">EN</option>
-                        <option value="pl" data-flag="flags/pl.svg">PL</option>
-                        <option value="cz" data-flag="flags/cz.svg">CZ</option>
-                    </select>
-                </div>
-                <div class="app-version">v1.0.0</div>
-                <button id="sidebarToggle" class="sidebar-toggle" aria-label="Sidebar umschalten">&gt;</button>
+            <div class="space-y-2">
+                <select id="languageSelect" class="w-full bg-gray-700 text-white p-2 rounded">
+                    <option value="de" data-flag="flags/de.svg">DE</option>
+                    <option value="en" data-flag="flags/gb.svg">EN</option>
+                    <option value="pl" data-flag="flags/pl.svg">PL</option>
+                    <option value="cz" data-flag="flags/cz.svg">CZ</option>
+                </select>
+                <div class="text-sm text-gray-400">v1.0.0</div>
+                <button id="sidebarToggle" class="bg-gray-700 p-2 rounded" aria-label="Sidebar umschalten">&gt;</button>
             </div>
         </nav>
-        <div id="generatorView" class="app-container">
+        <div class="flex-1 flex flex-col">
+            <header class="flex items-center justify-between bg-gray-900 text-white p-4">
+                <h1 class="text-xl font-semibold" data-i18n="Modern BVBS Korb Generator (MEP)">BVBS Korb Generator (MEP)</h1>
+                <img id="appLogo" src="./gb.png" alt="Firmenlogo" class="h-10">
+            </header>
+            <div id="generatorView" class="app-container flex-1 overflow-auto">
             <div class="main-grid">
                 <div class="input-column card">
                     <div class="card-header">
@@ -451,6 +443,9 @@
                 </div>
             </div>
         </div>
+
+        </div>
+    </div>
 
         <div id="savedOrdersModal" class="modal-overlay">
             <div class="modal-content card">


### PR DESCRIPTION
## Summary
- integrate Tailwind CSS via CDN
- rebuild header and sidebar navigation using Tailwind utilities

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898ea3be22c832d94bfe1efc58bde38