### PR TITLE
Fix language selector update and position

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -158,25 +158,23 @@ function applyTranslations() {
  * Sie löst das Neuladen der entsprechenden Sprachdatei aus.
  * @param {string} lang - Der Sprachcode ('de', 'en', 'pl', 'cz').
  */
-function setLanguage(lang) {
-    loadLanguage(lang);
+async function setLanguage(lang) {
+    await loadLanguage(lang);
 }
 
 // Initialisierung der Sprachlogik beim vollständigen Laden des DOM.
 // Dies stellt sicher, dass alle HTML-Elemente vorhanden sind, bevor Übersetzungen angewendet werden.
-document.addEventListener("DOMContentLoaded", () => {
+document.addEventListener("DOMContentLoaded", async () => {
     // Versuche, die zuletzt gewählte Sprache aus dem localStorage zu laden.
     // Wenn keine Sprache gespeichert ist, verwende Deutsch ('de') als Standard.
     const lang = localStorage.getItem("language") || "de";
-    loadLanguage(lang); // Lade die entsprechende Sprachdatei.
+    await loadLanguage(lang); // Lade die entsprechende Sprachdatei.
 
     const languageSelect = document.getElementById('languageSelect');
     if (languageSelect) {
         languageSelect.addEventListener('change', (e) => {
             setLanguage(e.target.value);
-            updateLanguageFlag();
         });
-        updateLanguageFlag();
     }
 
     // Dies ist ein spezieller Fall, falls das placeholder-Attribut nicht direkt

--- a/index.html
+++ b/index.html
@@ -41,6 +41,8 @@
                 </button>
             </div>
             <div class="nav-menu-bottom">
+                <div class="app-version">v1.0.0</div>
+                <button id="sidebarToggle" class="sidebar-toggle" aria-label="Sidebar umschalten">&gt;</button>
                 <div class="language-select">
                     <select id="languageSelect">
                         <option value="de" data-flag="flags/de.svg">DE</option>
@@ -49,8 +51,6 @@
                         <option value="cz" data-flag="flags/cz.svg">CZ</option>
                     </select>
                 </div>
-                <div class="app-version">v1.0.0</div>
-                <button id="sidebarToggle" class="sidebar-toggle" aria-label="Sidebar umschalten">&gt;</button>
             </div>
         </nav>
         <div id="generatorView" class="app-container">

--- a/styles.css
+++ b/styles.css
@@ -1249,21 +1249,6 @@ body.sidebar-open .nav-menu-bottom .app-version {
 			}
 		}
 
-			.language-select {
-			position: absolute;
-			top: 1rem;
-			right: 1rem;
-			background: var(--background-color);
-			border-radius: 4px;
-			padding: 0.2rem 0.5rem;
-			}
-
-                       .language-select select {
-                        border: none;
-                        background: transparent;
-                        font-size: 0.9rem;
-                        }
-
                         /* Label layout editing */
                         #printableLabel.label-edit-mode,
                         #printableLabel2.label-edit-mode {


### PR DESCRIPTION
## Summary
- ensure language change applies by awaiting translation load and simplifying listener
- reposition language selector at bottom of sidebar and remove conflicting styles

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6898f08fb090832d821fc86090ea109e