### PR TITLE
Fix zone highlight coloring by using correct zone length

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -1208,9 +1208,8 @@ function updateZonesPerLabel(value) {
                                     const pitch = zone.pitch;
                                     const dia = zone.dia;
 
-                                    const zoneWidth = numStirrups * pitch;
-                                    const zoneLength = numStirrups > 1 && pitch > 0 ? (numStirrups - 1) * pitch : 0;
-                                    stirrupZoneTotalLength += zoneWidth;
+                                    const zoneLength = numStirrups > 0 && pitch > 0 ? (numStirrups - 1) * pitch : 0;
+                                    stirrupZoneTotalLength += zoneLength;
 
                                     const isHighlighted = highlightedZoneDisplayIndex === displayIndex;
                                     const zoneColorIndex = index % NUM_ZONE_COLORS_AVAILABLE;
@@ -1224,8 +1223,8 @@ function updateZonesPerLabel(value) {
 
                                     if (numStirrups > 0) {
                                         const zoneStartScaled = PADDING_VISUAL + zoneStart * scale;
-                                        if (zoneWidth > 0) {
-                                            svgContent += `<rect class="${zoneBgFillClass}" x="${Math.round(zoneStartScaled)}" y="${Math.round(centerY - STIRRUP_HEIGHT_VISUAL / 2)}" width="${Math.round(zoneWidth * scale)}" height="${Math.round(STIRRUP_HEIGHT_VISUAL)}"/>`;
+                                        if (zoneLength > 0) {
+                                            svgContent += `<rect class="${zoneBgFillClass}" x="${Math.round(zoneStartScaled)}" y="${Math.round(centerY - STIRRUP_HEIGHT_VISUAL / 2)}" width="${Math.round(zoneLength * scale)}" height="${Math.round(STIRRUP_HEIGHT_VISUAL)}"/>`;
                                         }
                                         for (let j = 0; j < numStirrups; j++) {
                                             const stirrupPos = zoneStart + j * pitch;
@@ -1269,12 +1268,12 @@ function updateZonesPerLabel(value) {
                                         if (numStirrups > 1 && pitch > 0) {
                                             const pitchStartScaled = PADDING_VISUAL + zoneStart * scale;
                                             const pitchEndScaled = pitchStartScaled + pitch * scale;
-                                            if (pitchEndScaled <= zoneStartScaled + (zoneWidth * scale) + 1.1 && pitch * scale > 5) {
+                                            if (pitchEndScaled <= zoneStartScaled + (zoneLength * scale) + 1.1 && pitch * scale > 5) {
                                                 svgContent += buildDimensionLineSvg(pitchStartScaled, dimLineYPitch, pitchEndScaled, dimLineYPitch, `p=${pitch}`, 0, `dim-text-default ${zoneColorIndex}`, `dim-line-default ${zoneColorIndex}`, 'left');
                                             }
                                         }
 
-                                        currentPositionMm += zoneWidth;
+                                        currentPositionMm += zoneLength;
                                     }
                                     svgContent += `</g>`;
                                 });


### PR DESCRIPTION
## Summary
- compute zone lengths without extra pitch and use them for background rectangles
- update pitch dimension and zone advancement to rely on new zone length

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689907ca7320832d871af5c09879e550