### PR TITLE
Add configurable dimensions to BF2D preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -606,7 +606,19 @@
                                 <h2 class="card-title" data-i18n="SVG Vorschau">SVG Vorschau</h2>
                             </div>
                             <div class="bf2d-preview-container">
-                                <svg id="bf2dPreviewSvg" role="img" aria-label="BF2D Vorschau"></svg>
+                                <div class="bf2d-preview-controls">
+                                    <div class="bf2d-toggle">
+                                        <input type="checkbox" id="bf2dShowLengths" checked>
+                                        <label for="bf2dShowLengths" data-i18n="Längen anzeigen">Längen anzeigen</label>
+                                    </div>
+                                    <div class="bf2d-toggle">
+                                        <input type="checkbox" id="bf2dShowRadii" checked>
+                                        <label for="bf2dShowRadii" data-i18n="Radien anzeigen">Radien anzeigen</label>
+                                    </div>
+                                </div>
+                                <div class="bf2d-preview-stage">
+                                    <svg id="bf2dPreviewSvg" role="img" aria-label="BF2D Vorschau"></svg>
+                                </div>
                             </div>
                             <p id="bf2dPreviewNote" class="info-text" aria-live="polite"></p>
                         </div>

--- a/lang/cz.json
+++ b/lang/cz.json
@@ -189,6 +189,8 @@
   "Biegerollendurchmesser (mm)": "Průměr ohýbacího válce (mm)",
   "Stückzahl": "Počet kusů",
   "Stahlsorte": "Třída oceli",
+  "Längen anzeigen": "Zobrazit délky",
+  "Radien anzeigen": "Zobrazit poloměry",
   "Gesamtlänge": "Celková délka",
   "Gerade Länge": "Délka přímých částí",
   "Bogenlänge": "Délka oblouků",

--- a/lang/de.json
+++ b/lang/de.json
@@ -189,6 +189,8 @@
   "Biegerollendurchmesser (mm)": "Biegerollendurchmesser (mm)",
   "Stückzahl": "Stückzahl",
   "Stahlsorte": "Stahlsorte",
+  "Längen anzeigen": "Längen anzeigen",
+  "Radien anzeigen": "Radien anzeigen",
   "Gesamtlänge": "Gesamtlänge",
   "Gerade Länge": "Gerade Länge",
   "Bogenlänge": "Bogenlänge",

--- a/lang/en.json
+++ b/lang/en.json
@@ -189,6 +189,8 @@
   "Biegerollendurchmesser (mm)": "Bending roll diameter (mm)",
   "Stückzahl": "Quantity",
   "Stahlsorte": "Steel grade",
+  "Längen anzeigen": "Show lengths",
+  "Radien anzeigen": "Show radii",
   "Gesamtlänge": "Total length",
   "Gerade Länge": "Straight length",
   "Bogenlänge": "Arc length",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -189,6 +189,8 @@
   "Biegerollendurchmesser (mm)": "Średnica rolki gięcia (mm)",
   "Stückzahl": "Liczba sztuk",
   "Stahlsorte": "Gatunek stali",
+  "Längen anzeigen": "Pokaż długości",
+  "Radien anzeigen": "Pokaż promienie",
   "Gesamtlänge": "Długość całkowita",
   "Gerade Länge": "Długość prostych",
   "Bogenlänge": "Długość łuków",

--- a/styles.css
+++ b/styles.css
@@ -1959,14 +1959,66 @@ select.status-select.done {
     border-radius: var(--border-radius);
     background: var(--light-bg-color);
     display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    align-items: stretch;
+    justify-content: flex-start;
+    padding: 1rem;
+}
+
+.bf2d-preview-controls {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 1.25rem;
+}
+
+.bf2d-preview-controls .bf2d-toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.9rem;
+    color: var(--text-color);
+}
+
+.bf2d-preview-stage {
+    flex: 1 1 auto;
+    min-height: 320px;
+    display: flex;
     align-items: center;
     justify-content: center;
-    padding: 1rem;
 }
 
 #bf2dPreviewSvg {
     width: 100%;
-    height: 320px;
+    height: 100%;
+}
+
+.bf2d-dimensions {
+    color: var(--text-color);
+}
+
+.bf2d-dimension-line,
+.bf2d-dimension-extension,
+.bf2d-dimension-arc {
+    fill: none;
+    stroke: currentColor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+
+.bf2d-dimension-extension {
+    stroke-opacity: 0.6;
+}
+
+.bf2d-dimension-text,
+.bf2d-angle-text {
+    fill: currentColor;
+    font-weight: 500;
+}
+
+.bf2d-angle-text {
+    opacity: 0.85;
 }
 
 .bf2d-svg-background {


### PR DESCRIPTION
## Summary
- render per-leg length dimensions and bend radius/angle annotations in the BF2D preview with adaptive label placement
- expose preview toggles for showing lengths or radii, including updated styling and translations across supported languages

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cb02212cc8832da80c4a8347612b66