### PR TITLE
Add stirrup previews to saved orders

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2088,3 +2088,96 @@ select.status-select.done {
     resize: vertical;
 }
 
+.production-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.production-list .production-item {
+    background-color: var(--card-bg-color);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    padding: 1rem;
+    box-shadow: var(--shadow-sm);
+}
+
+.saved-order-item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.saved-order-main {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: center;
+}
+
+.saved-order-preview-container {
+    flex: 0 0 140px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.saved-order-preview-container svg {
+    width: 100%;
+    height: auto;
+}
+
+.saved-order-preview-placeholder {
+    width: 100%;
+    text-align: center;
+    color: var(--text-muted-color);
+    font-size: 1.5rem;
+    line-height: 1;
+}
+
+.saved-order-info {
+    flex: 1 1 240px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.saved-order-name {
+    font-weight: 600;
+    color: var(--heading-color);
+    word-break: break-word;
+}
+
+.saved-order-details {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 0.25rem 1rem;
+    font-size: 0.85rem;
+    color: var(--text-color);
+}
+
+.saved-order-details strong {
+    font-weight: 600;
+    color: var(--text-muted-color);
+}
+
+.saved-order-actions {
+    justify-content: flex-end;
+    gap: 0.5rem;
+}
+
+@media (max-width: 640px) {
+    .saved-order-main {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .saved-order-preview-container {
+        flex-basis: auto;
+        width: 100%;
+    }
+}
+


### PR DESCRIPTION
## Summary
- generate compact SVG thumbnails for saved stirrup orders and render them next to the entry titles
- persist stirrup names with saved orders so they are visible in the list alongside the new preview
- refine the saved orders list layout to accommodate thumbnails and improve readability

## Testing
- not run (static project)


------
https://chatgpt.com/codex/tasks/task_e_68cb0dac3a68832d8072c8febf34d5c1