### PR TITLE
Add multi-line ABS import parser and positions UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -618,6 +618,39 @@
                             </div>
                             <ul id="bf2dErrorList" class="bf2d-error-list"></ul>
                         </div>
+                        <div class="card bf2d-import-card">
+                            <div class="card-header">
+                                <h2 class="card-title" data-i18n="ABS-Import">ABS-Import</h2>
+                                <div class="button-group" style="justify-content: flex-end;">
+                                    <button type="button" id="bf2dImportButton" class="btn-secondary">
+                                        <span data-i18n="ABS-Datei importieren">ABS-Datei importieren</span>
+                                    </button>
+                                    <button type="button" id="bf2dExportSelectionButton" class="btn-secondary" disabled>
+                                        <span data-i18n="Auswahl exportieren">Auswahl exportieren</span>
+                                    </button>
+                                </div>
+                            </div>
+                            <div class="bf2d-import-body">
+                                <div id="bf2dImportStatus" class="info-text" aria-live="polite"></div>
+                                <div class="bf2d-import-table-wrapper">
+                                    <table id="bf2dImportTable" class="full-width-table bf2d-import-table">
+                                        <thead>
+                                            <tr>
+                                                <th style="width:32px;"><input type="checkbox" id="bf2dImportSelectAll"></th>
+                                                <th data-i18n="Typ">Typ</th>
+                                                <th data-i18n="Pos.-Nr.">Pos.-Nr.</th>
+                                                <th data-i18n="⌀ (mm)">⌀ (mm)</th>
+                                                <th data-i18n="Länge gesamt">Länge gesamt</th>
+                                                <th data-i18n="Anzahl">Anzahl</th>
+                                                <th data-i18n="Prüfsumme">Prüfsumme</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody id="bf2dImportTableBody"></tbody>
+                                    </table>
+                                </div>
+                            </div>
+                            <input type="file" id="bf2dImportFileInput" accept=".abs,text/plain" style="display:none">
+                        </div>
                         <div class="card preview-card">
                             <div class="card-header">
                                 <h2 class="card-title" data-i18n="SVG Vorschau">SVG Vorschau</h2>

--- a/lang/cz.json
+++ b/lang/cz.json
@@ -239,5 +239,21 @@
   "Datensatz in Zwischenablage kopiert.": "Datová sada byla zkopírována do schránky.",
   "Clipboard nicht verfügbar.": "Schránka není k dispozici.",
   "ABS-Datei heruntergeladen.": "Soubor ABS byl stažen.",
-  "Keine gültige Vorschau verfügbar.": "Platný náhled není k dispozici."
+  "Keine gültige Vorschau verfügbar.": "Platný náhled není k dispozici.",
+  "ABS-Import": "Import ABS",
+  "ABS-Datei importieren": "Importovat soubor ABS",
+  "Auswahl exportieren": "Exportovat výběr",
+  "Keine Positionen importiert.": "Nebyla importována žádná pozice.",
+  "⌀ (mm)": "⌀ (mm)",
+  "Länge gesamt": "Celková délka",
+  "Prüfsumme": "Kontrolní součet",
+  "Typ": "Typ",
+  "Fehler beim Einlesen der ABS-Datei.": "Chyba při načítání souboru ABS.",
+  "{count} Positionen importiert.": "Importováno {count} pozic.",
+  "{count} mit Fehlern": "{count} s chybami",
+  "{count} mit Warnungen": "{count} s varováními",
+  "OK": "OK",
+  "Fehler": "Chyba",
+  "Fehlt": "Chybí",
+  "Keine Geometrie verfügbar.": "Geometrie není k dispozici."
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -239,5 +239,21 @@
   "Datensatz in Zwischenablage kopiert.": "Datensatz in Zwischenablage kopiert.",
   "Clipboard nicht verfügbar.": "Zwischenablage nicht verfügbar.",
   "ABS-Datei heruntergeladen.": "ABS-Datei heruntergeladen.",
-  "Keine gültige Vorschau verfügbar.": "Keine gültige Vorschau verfügbar."
+  "Keine gültige Vorschau verfügbar.": "Keine gültige Vorschau verfügbar.",
+  "ABS-Import": "ABS-Import",
+  "ABS-Datei importieren": "ABS-Datei importieren",
+  "Auswahl exportieren": "Auswahl exportieren",
+  "Keine Positionen importiert.": "Keine Positionen importiert.",
+  "⌀ (mm)": "⌀ (mm)",
+  "Länge gesamt": "Länge gesamt",
+  "Prüfsumme": "Prüfsumme",
+  "Typ": "Typ",
+  "Fehler beim Einlesen der ABS-Datei.": "Fehler beim Einlesen der ABS-Datei.",
+  "{count} Positionen importiert.": "{count} Positionen importiert.",
+  "{count} mit Fehlern": "{count} mit Fehlern",
+  "{count} mit Warnungen": "{count} mit Warnungen",
+  "OK": "OK",
+  "Fehler": "Fehler",
+  "Fehlt": "Fehlt",
+  "Keine Geometrie verfügbar.": "Keine Geometrie verfügbar."
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -239,5 +239,21 @@
   "Datensatz in Zwischenablage kopiert.": "Dataset copied to clipboard.",
   "Clipboard nicht verfügbar.": "Clipboard not available.",
   "ABS-Datei heruntergeladen.": "ABS file downloaded.",
-  "Keine gültige Vorschau verfügbar.": "No valid preview available."
+  "Keine gültige Vorschau verfügbar.": "No valid preview available.",
+  "ABS-Import": "ABS import",
+  "ABS-Datei importieren": "Import ABS file",
+  "Auswahl exportieren": "Export selection",
+  "Keine Positionen importiert.": "No positions imported.",
+  "⌀ (mm)": "⌀ (mm)",
+  "Länge gesamt": "Total length",
+  "Prüfsumme": "Checksum",
+  "Typ": "Type",
+  "Fehler beim Einlesen der ABS-Datei.": "Error reading ABS file.",
+  "{count} Positionen importiert.": "{count} positions imported.",
+  "{count} mit Fehlern": "{count} with errors",
+  "{count} mit Warnungen": "{count} with warnings",
+  "OK": "OK",
+  "Fehler": "Error",
+  "Fehlt": "Missing",
+  "Keine Geometrie verfügbar.": "No geometry available."
 }

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -239,5 +239,21 @@
   "Datensatz in Zwischenablage kopiert.": "Zbiór danych skopiowano do schowka.",
   "Clipboard nicht verfügbar.": "Schowek jest niedostępny.",
   "ABS-Datei heruntergeladen.": "Plik ABS został pobrany.",
-  "Keine gültige Vorschau verfügbar.": "Podgląd jest niedostępny."
+  "Keine gültige Vorschau verfügbar.": "Podgląd jest niedostępny.",
+  "ABS-Import": "Import ABS",
+  "ABS-Datei importieren": "Importuj plik ABS",
+  "Auswahl exportieren": "Eksportuj zaznaczenie",
+  "Keine Positionen importiert.": "Nie zaimportowano pozycji.",
+  "⌀ (mm)": "⌀ (mm)",
+  "Länge gesamt": "Długość całkowita",
+  "Prüfsumme": "Suma kontrolna",
+  "Typ": "Typ",
+  "Fehler beim Einlesen der ABS-Datei.": "Błąd podczas odczytu pliku ABS.",
+  "{count} Positionen importiert.": "Zaimportowano {count} pozycji.",
+  "{count} mit Fehlern": "{count} z błędami",
+  "{count} mit Warnungen": "{count} z ostrzeżeniami",
+  "OK": "OK",
+  "Fehler": "Błąd",
+  "Fehlt": "Brak",
+  "Keine Geometrie verfügbar.": "Brak dostępnej geometrii."
 }

--- a/styles.css
+++ b/styles.css
@@ -1900,6 +1900,76 @@ select.status-select.done {
     margin-top: 1.25rem;
 }
 
+.bf2d-import-card .card-header {
+    align-items: center;
+}
+
+.bf2d-import-body {
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.bf2d-import-table-wrapper {
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    background-color: var(--light-bg-color);
+    max-height: 320px;
+    overflow-y: auto;
+}
+
+.bf2d-import-table th,
+.bf2d-import-table td {
+    white-space: nowrap;
+    padding: 0.6rem 0.75rem;
+}
+
+.bf2d-import-select-cell {
+    text-align: center;
+}
+
+.bf2d-import-select {
+    cursor: pointer;
+}
+
+.bf2d-import-table tbody tr {
+    cursor: pointer;
+    transition: background-color 0.2s ease-in-out;
+}
+
+.bf2d-import-table tbody tr.bf2d-import-active {
+    outline: 2px solid var(--primary-color);
+    outline-offset: -2px;
+}
+
+.bf2d-import-table tbody tr.bf2d-import-error {
+    background-color: rgba(220, 53, 69, 0.12);
+}
+
+.bf2d-import-table tbody tr.bf2d-import-warning {
+    background-color: rgba(255, 193, 7, 0.12);
+}
+
+.bf2d-import-empty-row td,
+.bf2d-import-empty-cell {
+    padding: 1rem;
+    text-align: center;
+    color: var(--text-muted-color);
+}
+
+.bf2d-import-checksum-cell {
+    font-weight: 600;
+}
+
+.bf2d-import-checksum-error {
+    color: var(--danger-color);
+}
+
+.info-message {
+    color: var(--primary-color);
+}
+
 .bf2d-summary-item {
     background: rgba(var(--primary-color-rgb), 0.08);
     border: 1px solid var(--border-color);


### PR DESCRIPTION
## Summary
- add a parser for multi-line ABS files including block parsing, checksum validation, and geometry extraction
- integrate a positions import card with selection table, export, and editor/preview loading
- extend styling and translations to support the new import workflow

## Testing
- not run (not specified)


------
https://chatgpt.com/codex/tasks/task_e_68cb1c6de27c832d883e7655a8869480