### PR TITLE
Improve BFMA mesh usability

### DIFF
--- a/index.html
+++ b/index.html
@@ -826,6 +826,7 @@
                                 <th data-i18n="l (mm)">l (mm)</th>
                                 <th data-i18n="e (mm;.. / mm,n)">e (mm;.. / mm,n)</th>
                                 <th data-i18n="z">z</th>
+                                <th data-i18n="Anzahl (berechnet)">Anzahl (berechnet)</th>
                                 <th></th>
                             </tr>
                         </thead>
@@ -843,6 +844,7 @@
                                 <th data-i18n="l (mm)">l (mm)</th>
                                 <th data-i18n="e (mm;.. / mm,n)">e (mm;.. / mm,n)</th>
                                 <th data-i18n="z">z</th>
+                                <th data-i18n="Anzahl (berechnet)">Anzahl (berechnet)</th>
                                 <th></th>
                             </tr>
                         </thead>
@@ -861,6 +863,7 @@
                                 <th data-i18n="w (°)">w (°)</th>
                                 <th data-i18n="e (mm;.. / mm,n)">e (mm;.. / mm,n)</th>
                                 <th data-i18n="z">z</th>
+                                <th data-i18n="Anzahl (berechnet)">Anzahl (berechnet)</th>
                                 <th></th>
                             </tr>
                         </thead>

--- a/lang/cz.json
+++ b/lang/cz.json
@@ -280,6 +280,7 @@
   "y (mm)": "y (mm)",
   "e (mm;.. / mm,n)": "e (mm;.. / mm,n)",
   "z": "z",
+  "Anzahl (berechnet)": "Počet (vypočtený)",
   "w (°)": "w (°)",
   "Y-Stab hinzufügen": "Add Y-bar",
   "X-Stab hinzufügen": "Add X-bar",
@@ -300,5 +301,6 @@
   "Matte \"{name}\" gespeichert.": "Mesh \"{name}\" saved.",
   "Matte \"{name}\" geladen.": "Mesh \"{name}\" loaded.",
   "Matte \"{name}\" wirklich löschen?": "Really delete mesh \"{name}\"?",
-  "Matte \"{name}\" gelöscht.": "Mesh \"{name}\" deleted."
+  "Matte \"{name}\" gelöscht.": "Mesh \"{name}\" deleted.",
+  "Stab duplizieren": "Duplikovat prut"
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -280,6 +280,7 @@
   "y (mm)": "y (mm)",
   "e (mm;.. / mm,n)": "e (mm;.. / mm,n)",
   "z": "z",
+  "Anzahl (berechnet)": "Anzahl (berechnet)",
   "w (°)": "w (°)",
   "Y-Stab hinzufügen": "Y-Stab hinzufügen",
   "X-Stab hinzufügen": "X-Stab hinzufügen",
@@ -300,5 +301,6 @@
   "Matte \"{name}\" gespeichert.": "Matte \"{name}\" gespeichert.",
   "Matte \"{name}\" geladen.": "Matte \"{name}\" geladen.",
   "Matte \"{name}\" wirklich löschen?": "Matte \"{name}\" wirklich löschen?",
-  "Matte \"{name}\" gelöscht.": "Matte \"{name}\" gelöscht."
+  "Matte \"{name}\" gelöscht.": "Matte \"{name}\" gelöscht.",
+  "Stab duplizieren": "Stab duplizieren"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -280,6 +280,7 @@
   "y (mm)": "y (mm)",
   "e (mm;.. / mm,n)": "e (mm;.. / mm,n)",
   "z": "z",
+  "Anzahl (berechnet)": "Calculated count",
   "w (°)": "w (°)",
   "Y-Stab hinzufügen": "Add Y-bar",
   "X-Stab hinzufügen": "Add X-bar",
@@ -300,5 +301,6 @@
   "Matte \"{name}\" gespeichert.": "Mesh \"{name}\" saved.",
   "Matte \"{name}\" geladen.": "Mesh \"{name}\" loaded.",
   "Matte \"{name}\" wirklich löschen?": "Really delete mesh \"{name}\"?",
-  "Matte \"{name}\" gelöscht.": "Mesh \"{name}\" deleted."
+  "Matte \"{name}\" gelöscht.": "Mesh \"{name}\" deleted.",
+  "Stab duplizieren": "Duplicate bar"
 }

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -280,6 +280,7 @@
   "y (mm)": "y (mm)",
   "e (mm;.. / mm,n)": "e (mm;.. / mm,n)",
   "z": "z",
+  "Anzahl (berechnet)": "Liczba (obliczona)",
   "w (°)": "w (°)",
   "Y-Stab hinzufügen": "Add Y-bar",
   "X-Stab hinzufügen": "Add X-bar",
@@ -300,5 +301,6 @@
   "Matte \"{name}\" gespeichert.": "Mesh \"{name}\" saved.",
   "Matte \"{name}\" geladen.": "Mesh \"{name}\" loaded.",
   "Matte \"{name}\" wirklich löschen?": "Really delete mesh \"{name}\"?",
-  "Matte \"{name}\" gelöscht.": "Mesh \"{name}\" deleted."
+  "Matte \"{name}\" gelöscht.": "Mesh \"{name}\" deleted.",
+  "Stab duplizieren": "Duplikuj pręt"
 }

--- a/styles.css
+++ b/styles.css
@@ -2431,6 +2431,22 @@ select.status-select.done {
     transform: translateY(-1px);
 }
 
+.table-action-group {
+    display: inline-flex;
+    gap: 0.25rem;
+}
+
+.bfma-count-cell {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    min-width: 3.25rem;
+}
+
+.bfma-count-cell.is-zero {
+    color: var(--danger-color);
+    font-weight: 600;
+}
+
 .table-empty-hint {
     text-align: center;
     padding: 1rem;


### PR DESCRIPTION
## Summary
- add a duplicate action for BFMA bars that reuses spacing data to position the copy
- surface the calculated bar count directly in the tables with helpful tooltips
- update styles and translations to support the new controls

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ccd190d860832d9d81d8ee5db093ba