### PR TITLE
Add dedicated settings view for configurable preferences

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,14 +95,12 @@
                 </div>
             </div>
             <div class="sidebar-footer">
-                <div class="language-select">
-                    <select id="languageSelect">
-                        <option value="de" data-flag="flags/de.svg">DE</option>
-                        <option value="en" data-flag="flags/gb.svg">EN</option>
-                        <option value="pl" data-flag="flags/pl.svg">PL</option>
-                        <option value="cz" data-flag="flags/cz.svg">CZ</option>
-                    </select>
-                </div>
+                <button id="showSettingsBtn" class="sidebar-link sidebar-link--settings" data-view-target="settingsView" data-i18n-title="Einstellungen" title="Einstellungen">
+                    <svg viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M12 8a4 4 0 1 1 0 8 4 4 0 0 1 0-8zm9 4c0-.7-.08-1.38-.23-2.03l2.02-1.57-1.9-3.3-2.4.74a8.03 8.03 0 0 0-3.5-2.02L14.5 1h-5l-.49 2.82a8.03 8.03 0 0 0-3.5 2.02l-2.4-.74-1.9 3.3 2.02 1.57A8.27 8.27 0 0 0 3 12c0 .7.08 1.38.23 2.03l-2.02 1.57 1.9 3.3 2.4-.74a8.03 8.03 0 0 0 3.5 2.02l.49 2.82h5l.49-2.82a8.03 8.03 0 0 0 3.5-2.02l2.4.74 1.9-3.3-2.02-1.57c.15-.65.23-1.33.23-2.03z" />
+                    </svg>
+                    <span class="sidebar-text" data-i18n="Einstellungen">Einstellungen</span>
+                </button>
                 <div class="app-version">v1.0.0</div>
             </div>
         </aside>
@@ -985,6 +983,69 @@
                                 </tbody>
                             </table>
                         </div>
+                    </div>
+                </div>
+                <div id="settingsView" class="app-container" style="display:none;">
+                    <header class="settings-header">
+                        <h1 data-i18n="Einstellungen">Einstellungen</h1>
+                        <p data-i18n="Einstellungen Beschreibung">Verwalte Sprache, Darstellung und persönliche Optionen der Anwendung.</p>
+                    </header>
+                    <div class="settings-grid">
+                        <section class="card settings-card">
+                            <div class="card-header">
+                                <h2 class="card-title" data-i18n="Spracheinstellungen">Spracheinstellungen</h2>
+                                <p class="card-subtitle" data-i18n="Spracheinstellungen Beschreibung">Wähle deine bevorzugte Sprache für die Oberfläche.</p>
+                            </div>
+                            <div class="settings-section">
+                                <label for="languageSelect" class="settings-label" data-i18n="Sprache wählen">Sprache wählen</label>
+                                <div class="language-select">
+                                    <select id="languageSelect">
+                                        <option value="de" data-flag="flags/de.svg">DE</option>
+                                        <option value="en" data-flag="flags/gb.svg">EN</option>
+                                        <option value="pl" data-flag="flags/pl.svg">PL</option>
+                                        <option value="cz" data-flag="flags/cz.svg">CZ</option>
+                                    </select>
+                                </div>
+                            </div>
+                        </section>
+                        <section class="card settings-card">
+                            <div class="card-header">
+                                <h2 class="card-title" data-i18n="Personalisierung">Personalisierung</h2>
+                                <p class="card-subtitle" data-i18n="Personalisierung Beschreibung">Passe Aussehen und Verhalten der Oberfläche an deine Bedürfnisse an.</p>
+                            </div>
+                            <div class="settings-section">
+                                <div class="settings-toggle">
+                                    <div class="settings-toggle-text">
+                                        <span class="settings-toggle-title" data-i18n="Dunkles Design aktivieren">Dunkles Design aktivieren</span>
+                                        <span class="settings-toggle-description" data-i18n="Dunkles Design aktivieren Beschreibung">Schont die Augen bei schlechten Lichtverhältnissen durch eine dunkle Farbpalette.</span>
+                                    </div>
+                                    <label class="settings-switch">
+                                        <input type="checkbox" id="darkModeToggle">
+                                        <span class="slider" aria-hidden="true"></span>
+                                    </label>
+                                </div>
+                                <div class="settings-toggle">
+                                    <div class="settings-toggle-text">
+                                        <span class="settings-toggle-title" data-i18n="Kompakte Darstellung aktivieren">Kompakte Darstellung aktivieren</span>
+                                        <span class="settings-toggle-description" data-i18n="Kompakte Darstellung aktivieren Beschreibung">Reduziert Abstände und verdichtet Tabellen für mehr Inhalte auf einen Blick.</span>
+                                    </div>
+                                    <label class="settings-switch">
+                                        <input type="checkbox" id="compactModeToggle">
+                                        <span class="slider" aria-hidden="true"></span>
+                                    </label>
+                                </div>
+                                <div class="settings-toggle">
+                                    <div class="settings-toggle-text">
+                                        <span class="settings-toggle-title" data-i18n="Animationen reduzieren">Animationen reduzieren</span>
+                                        <span class="settings-toggle-description" data-i18n="Animationen reduzieren Beschreibung">Minimiert visuelle Bewegung für eine ruhigere Darstellung.</span>
+                                    </div>
+                                    <label class="settings-switch">
+                                        <input type="checkbox" id="reduceMotionToggle">
+                                        <span class="slider" aria-hidden="true"></span>
+                                    </label>
+                                </div>
+                            </div>
+                        </section>
                     </div>
                 </div>
             </main>

--- a/lang/cz.json
+++ b/lang/cz.json
@@ -302,5 +302,18 @@
   "Matte \"{name}\" geladen.": "Mesh \"{name}\" loaded.",
   "Matte \"{name}\" wirklich löschen?": "Really delete mesh \"{name}\"?",
   "Matte \"{name}\" gelöscht.": "Mesh \"{name}\" deleted.",
-  "Stab duplizieren": "Duplikovat prut"
+  "Stab duplizieren": "Duplikovat prut",
+  "Einstellungen": "Nastavení",
+  "Einstellungen Beschreibung": "Spravujte jazyk, vzhled a osobní preference aplikace.",
+  "Spracheinstellungen": "Jazykové nastavení",
+  "Spracheinstellungen Beschreibung": "Vyberte preferovaný jazyk rozhraní.",
+  "Sprache wählen": "Vyberte jazyk",
+  "Personalisierung": "Personalizace",
+  "Personalisierung Beschreibung": "Přizpůsobte vzhled a chování rozhraní svým potřebám.",
+  "Dunkles Design aktivieren": "Zapnout tmavý režim",
+  "Dunkles Design aktivieren Beschreibung": "Přepne barevné schéma na tmavé pro práci při slabém světle.",
+  "Kompakte Darstellung aktivieren": "Zapnout kompaktní zobrazení",
+  "Kompakte Darstellung aktivieren Beschreibung": "Zmenší rozestupy a zhušťuje tabulky pro více informací na obrazovce.",
+  "Animationen reduzieren": "Omezit animace",
+  "Animationen reduzieren Beschreibung": "Minimalizuje pohyb v rozhraní pro klidnější práci."
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -302,5 +302,18 @@
   "Matte \"{name}\" geladen.": "Matte \"{name}\" geladen.",
   "Matte \"{name}\" wirklich löschen?": "Matte \"{name}\" wirklich löschen?",
   "Matte \"{name}\" gelöscht.": "Matte \"{name}\" gelöscht.",
-  "Stab duplizieren": "Stab duplizieren"
+  "Stab duplizieren": "Stab duplizieren",
+  "Einstellungen": "Einstellungen",
+  "Einstellungen Beschreibung": "Verwalte Sprache, Darstellung und persönliche Optionen der Anwendung.",
+  "Spracheinstellungen": "Spracheinstellungen",
+  "Spracheinstellungen Beschreibung": "Wähle deine bevorzugte Sprache für die Oberfläche.",
+  "Sprache wählen": "Sprache wählen",
+  "Personalisierung": "Personalisierung",
+  "Personalisierung Beschreibung": "Passe Aussehen und Verhalten der Oberfläche an deine Bedürfnisse an.",
+  "Dunkles Design aktivieren": "Dunkles Design aktivieren",
+  "Dunkles Design aktivieren Beschreibung": "Schont die Augen bei schlechten Lichtverhältnissen durch eine dunkle Farbpalette.",
+  "Kompakte Darstellung aktivieren": "Kompakte Darstellung aktivieren",
+  "Kompakte Darstellung aktivieren Beschreibung": "Reduziert Abstände und verdichtet Tabellen für mehr Inhalte auf einen Blick.",
+  "Animationen reduzieren": "Animationen reduzieren",
+  "Animationen reduzieren Beschreibung": "Minimiert visuelle Bewegung für eine ruhigere Darstellung."
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -302,5 +302,18 @@
   "Matte \"{name}\" geladen.": "Mesh \"{name}\" loaded.",
   "Matte \"{name}\" wirklich löschen?": "Really delete mesh \"{name}\"?",
   "Matte \"{name}\" gelöscht.": "Mesh \"{name}\" deleted.",
-  "Stab duplizieren": "Duplicate bar"
+  "Stab duplizieren": "Duplicate bar",
+  "Einstellungen": "Settings",
+  "Einstellungen Beschreibung": "Manage language, appearance and personal preferences for the application.",
+  "Spracheinstellungen": "Language settings",
+  "Spracheinstellungen Beschreibung": "Choose your preferred interface language.",
+  "Sprache wählen": "Choose language",
+  "Personalisierung": "Personalization",
+  "Personalisierung Beschreibung": "Adjust the look and behaviour of the interface to your needs.",
+  "Dunkles Design aktivieren": "Enable dark mode",
+  "Dunkles Design aktivieren Beschreibung": "Switch to a dark colour scheme for working in low-light environments.",
+  "Kompakte Darstellung aktivieren": "Enable compact layout",
+  "Kompakte Darstellung aktivieren Beschreibung": "Tightens spacing and table rows to show more information at once.",
+  "Animationen reduzieren": "Reduce animations",
+  "Animationen reduzieren Beschreibung": "Minimise motion effects for a calmer, distraction-free experience."
 }

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -302,5 +302,18 @@
   "Matte \"{name}\" geladen.": "Mesh \"{name}\" loaded.",
   "Matte \"{name}\" wirklich löschen?": "Really delete mesh \"{name}\"?",
   "Matte \"{name}\" gelöscht.": "Mesh \"{name}\" deleted.",
-  "Stab duplizieren": "Duplikuj pręt"
+  "Stab duplizieren": "Duplikuj pręt",
+  "Einstellungen": "Ustawienia",
+  "Einstellungen Beschreibung": "Zarządzaj językiem, wyglądem i osobistymi preferencjami aplikacji.",
+  "Spracheinstellungen": "Ustawienia języka",
+  "Spracheinstellungen Beschreibung": "Wybierz preferowany język interfejsu.",
+  "Sprache wählen": "Wybierz język",
+  "Personalisierung": "Personalizacja",
+  "Personalisierung Beschreibung": "Dostosuj wygląd i zachowanie interfejsu do swoich potrzeb.",
+  "Dunkles Design aktivieren": "Włącz tryb ciemny",
+  "Dunkles Design aktivieren Beschreibung": "Zmienia paletę kolorów na ciemną, wygodną przy słabym oświetleniu.",
+  "Kompakte Darstellung aktivieren": "Włącz kompaktowy widok",
+  "Kompakte Darstellung aktivieren Beschreibung": "Zmniejsza odstępy i zagęszcza tabele, aby pokazać więcej danych.",
+  "Animationen reduzieren": "Ogranicz animacje",
+  "Animationen reduzieren Beschreibung": "Minimalizuje ruch w interfejsie dla spokojniejszej pracy."
 }

--- a/production.js
+++ b/production.js
@@ -35,7 +35,59 @@ function updateBatchButtonsState() {
     if (printBtn) printBtn.disabled = !hasSelection;
 }
 
-const APP_VIEW_IDS = ['generatorView', 'bf2dView', 'bfmaView', 'productionView'];
+const APP_VIEW_IDS = ['generatorView', 'bf2dView', 'bfmaView', 'productionView', 'settingsView'];
+
+const SETTINGS_STORAGE_KEY = 'bvbsAppSettings';
+const DEFAULT_APP_SETTINGS = {
+    theme: 'light',
+    density: 'comfortable',
+    motion: 'full'
+};
+let appSettings = { ...DEFAULT_APP_SETTINGS };
+
+function loadAppSettings() {
+    try {
+        const stored = localStorage.getItem(SETTINGS_STORAGE_KEY);
+        if (stored) {
+            const parsed = JSON.parse(stored);
+            if (parsed && typeof parsed === 'object') {
+                appSettings = { ...DEFAULT_APP_SETTINGS, ...parsed };
+            }
+        }
+    } catch (error) {
+        console.error('Could not parse application settings', error);
+        appSettings = { ...DEFAULT_APP_SETTINGS };
+    }
+}
+
+function persistAppSettings() {
+    try {
+        localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(appSettings));
+    } catch (error) {
+        console.error('Could not store application settings', error);
+    }
+}
+
+function applyAppSettings() {
+    document.body.dataset.theme = appSettings.theme;
+    document.body.dataset.density = appSettings.density;
+    document.body.dataset.motion = appSettings.motion;
+
+    const darkModeToggle = document.getElementById('darkModeToggle');
+    if (darkModeToggle) {
+        darkModeToggle.checked = appSettings.theme === 'dark';
+    }
+
+    const compactModeToggle = document.getElementById('compactModeToggle');
+    if (compactModeToggle) {
+        compactModeToggle.checked = appSettings.density === 'compact';
+    }
+
+    const reduceMotionToggle = document.getElementById('reduceMotionToggle');
+    if (reduceMotionToggle) {
+        reduceMotionToggle.checked = appSettings.motion === 'reduced';
+    }
+}
 
 function setActiveNavigation(view) {
     document.body.dataset.activeView = view;
@@ -83,6 +135,10 @@ function showBf2dView() {
 
 function showBfmaView() {
     showView('bfmaView');
+}
+
+function showSettingsView() {
+    showView('settingsView');
 }
 
 function openGeneratorAndClick(buttonId) {
@@ -249,6 +305,8 @@ function renderProductionList() {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+    loadAppSettings();
+    applyAppSettings();
     loadProductionList();
     const updateSidebarState = () => {
         const isOpen = document.body.classList.contains('sidebar-open');
@@ -311,6 +369,10 @@ document.addEventListener('DOMContentLoaded', () => {
         showProductionView();
         closeSidebarOnSmallScreens();
     });
+    document.getElementById('showSettingsBtn')?.addEventListener('click', () => {
+        showSettingsView();
+        closeSidebarOnSmallScreens();
+    });
     document.getElementById('quickReleaseButton')?.addEventListener('click', () => {
         openGeneratorAndClick('releaseButton');
         closeSidebarOnSmallScreens();
@@ -326,6 +388,24 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('quickPrintLabelButton')?.addEventListener('click', () => {
         openGeneratorAndClick('printLabelButton');
         closeSidebarOnSmallScreens();
+    });
+    const darkModeToggle = document.getElementById('darkModeToggle');
+    darkModeToggle?.addEventListener('change', (e) => {
+        appSettings.theme = e.target.checked ? 'dark' : 'light';
+        applyAppSettings();
+        persistAppSettings();
+    });
+    const compactModeToggle = document.getElementById('compactModeToggle');
+    compactModeToggle?.addEventListener('change', (e) => {
+        appSettings.density = e.target.checked ? 'compact' : 'comfortable';
+        applyAppSettings();
+        persistAppSettings();
+    });
+    const reduceMotionToggle = document.getElementById('reduceMotionToggle');
+    reduceMotionToggle?.addEventListener('change', (e) => {
+        appSettings.motion = e.target.checked ? 'reduced' : 'full';
+        applyAppSettings();
+        persistAppSettings();
     });
     document.getElementById('releaseButton')?.addEventListener('click', () => {
         const input = document.getElementById('releaseStartzeit');
@@ -448,6 +528,8 @@ document.addEventListener('DOMContentLoaded', () => {
             window.print();
         }, 100);
     });
+
+    applyAppSettings();
 
     showGeneratorView();
 });

--- a/styles.css
+++ b/styles.css
@@ -87,6 +87,71 @@ body {
     -moz-osx-font-smoothing: grayscale;
 }
 
+body[data-theme="dark"] {
+    --body-bg-color: #0b1220;
+    --card-bg-color: rgba(15, 23, 42, 0.88);
+    --light-bg-color: rgba(30, 41, 59, 0.82);
+    --input-bg-color: rgba(15, 23, 42, 0.65);
+    --input-focus-bg-color: rgba(30, 41, 59, 0.88);
+    --text-color: #e2e8f0;
+    --text-muted-color: rgba(148, 163, 184, 0.85);
+    --heading-color: #f8fafc;
+    --border-color: rgba(148, 163, 184, 0.32);
+    --svg-text-color: #e2e8f0;
+    --svg-dim-line-color: rgba(148, 163, 184, 0.55);
+    --hatch-line-color: rgba(148, 163, 184, 0.28);
+}
+
+body[data-theme="dark"] .app-header {
+    background: linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(30, 41, 59, 0.92));
+}
+
+body[data-theme="dark"] .card {
+    box-shadow: 0 18px 36px rgba(8, 15, 30, 0.55);
+}
+
+body[data-theme="dark"] .settings-switch .slider {
+    background: rgba(148, 163, 184, 0.28);
+}
+
+body[data-theme="dark"] .settings-switch .slider::before {
+    background: rgba(15, 23, 42, 0.9);
+}
+
+body[data-density="compact"] .app-container {
+    padding: 0 calc(var(--page-side-padding) * 0.65);
+}
+
+body[data-density="compact"] .card {
+    padding: 1.1rem;
+    margin-bottom: 1.35rem;
+}
+
+body[data-density="compact"] .form-group {
+    margin-bottom: 0.85rem;
+}
+
+body[data-density="compact"] .sidebar-link {
+    padding: 0.65rem 0.85rem;
+}
+
+body[data-density="compact"] .settings-toggle {
+    padding: 0.6rem 0;
+}
+
+body[data-density="compact"] .settings-section {
+    gap: 1rem;
+}
+
+body[data-motion="reduced"] *,
+body[data-motion="reduced"] *::before,
+body[data-motion="reduced"] *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+}
+
 body.sidebar-open {
     --sidebar-width: var(--sidebar-expanded-width);
 }
@@ -725,6 +790,140 @@ select {
 .language-select option[value="pl"] { background-image: url('flags/pl.svg'); }
 .language-select option[value="cz"] { background-image: url('flags/cz.svg'); }
 
+.settings-header {
+    margin-bottom: 2rem;
+}
+
+.settings-header h1 {
+    margin: 0;
+    font-size: 1.85rem;
+    font-weight: 600;
+    color: var(--heading-color);
+}
+
+.settings-header p {
+    margin: 0.5rem 0 0;
+    max-width: 640px;
+    color: var(--text-muted-color);
+    font-size: 1rem;
+}
+
+.settings-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 1.75rem;
+}
+
+.settings-card {
+    max-height: none;
+    overflow: visible;
+    height: auto;
+    flex: none;
+}
+
+.settings-section {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.settings-label {
+    font-weight: 600;
+    color: var(--heading-color);
+}
+
+.settings-toggle {
+    display: flex;
+    align-items: center;
+    gap: 1.25rem;
+    padding: 0.75rem 0;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.settings-toggle:first-child {
+    padding-top: 0;
+}
+
+.settings-toggle:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
+.settings-toggle-text {
+    flex: 1;
+    min-width: 0;
+}
+
+.settings-toggle-title {
+    display: block;
+    font-weight: 600;
+    color: var(--heading-color);
+}
+
+.settings-toggle-description {
+    display: block;
+    margin-top: 0.35rem;
+    color: var(--text-muted-color);
+    font-size: 0.9rem;
+}
+
+.settings-switch {
+    position: relative;
+    display: inline-flex;
+    width: 50px;
+    height: 28px;
+    flex-shrink: 0;
+}
+
+.settings-switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.settings-switch .slider {
+    position: absolute;
+    inset: 0;
+    cursor: pointer;
+    background: rgba(148, 163, 184, 0.35);
+    border-radius: 999px;
+    transition: background 0.3s ease;
+}
+
+.settings-switch .slider::before {
+    content: '';
+    position: absolute;
+    width: 22px;
+    height: 22px;
+    left: 3px;
+    top: 3px;
+    border-radius: 50%;
+    background: var(--card-bg-color);
+    box-shadow: var(--shadow-sm);
+    transition: transform 0.3s ease;
+}
+
+.settings-switch input:checked + .slider {
+    background: rgba(var(--primary-color-rgb), 0.6);
+}
+
+.settings-switch input:checked + .slider::before {
+    transform: translateX(22px);
+}
+
+.settings-switch input:focus + .slider {
+    box-shadow: 0 0 0 3px rgba(var(--primary-color-rgb), 0.25);
+}
+
+@media (max-width: 768px) {
+    .settings-grid {
+        grid-template-columns: 1fr;
+    }
+    .settings-toggle {
+        align-items: flex-start;
+    }
+}
+
 .sidebar-toggle {
     border: 1px solid rgba(148, 163, 184, 0.32);
     background: rgba(15, 23, 42, 0.58);
@@ -898,6 +1097,16 @@ body.sidebar-open .sidebar-toggle svg {
 
 .sidebar-link--action:hover {
     background: linear-gradient(135deg, rgba(74, 144, 226, 0.35), rgba(74, 144, 226, 0.6));
+}
+
+.sidebar-link--settings {
+    border: 1px solid rgba(148, 163, 184, 0.24);
+    background: rgba(15, 23, 42, 0.4);
+    color: var(--sidebar-text-color);
+}
+
+.sidebar-link--settings:hover {
+    background: rgba(148, 163, 184, 0.24);
 }
 
 .sidebar-text {


### PR DESCRIPTION
## Summary
- add a sidebar entry and dedicated settings page that moves the language selector and introduces appearance toggles
- persist theme, density, and motion preferences in localStorage and apply them across the interface
- style the settings experience and translate the new copy for all supported languages

## Testing
- No automated tests (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ccdb7f4964832da65a05a9fb9cab78