### PR TITLE
Remove app header and rely on sidebar navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,28 +105,6 @@
             </div>
         </aside>
         <div class="app-main">
-            <div class="app-header-wrapper">
-                <header class="app-header">
-                    <div class="left-section">
-                        <button id="sidebarToggle" class="sidebar-toggle" type="button" data-sidebar-toggle aria-expanded="false" aria-label="Menü ausklappen">
-                            <svg viewBox="0 0 24 24" aria-hidden="true">
-                                <path d="M9 5l7 7-7 7" />
-                            </svg>
-                        </button>
-                        <div class="title-group">
-                            <span class="title-eyebrow">BVBS Suite</span>
-                            <h1 class="app-title" data-i18n="Modern BVBS Korb Generator (MEP)">BVBS Korb Generator (MEP)</h1>
-                            <p class="app-subtitle" data-i18n="Digitale Fertigung im Blick">Digitale Fertigung im Blick</p>
-                        </div>
-                    </div>
-                    <div class="right-section">
-                        <span class="header-badge" data-i18n="Feature-Optimierungen aktiv">Feature-Optimierungen aktiv</span>
-                        <div class="logo-area">
-                            <img id="appLogo" src="./gb.png" alt="Firmenlogo">
-                        </div>
-                    </div>
-                </header>
-            </div>
             <main class="app-content">
                 <div id="generatorView" class="app-container">
             <div class="main-grid">

--- a/styles.css
+++ b/styles.css
@@ -485,6 +485,7 @@ select {
     flex-direction: column;
     background: var(--body-bg-color);
     position: relative;
+    padding: 2rem 0 2.5rem;
 }
 
 .app-header-wrapper {
@@ -1182,7 +1183,7 @@ body:not(.sidebar-open) .sidebar-scroll {
     .app-sidebar {
         width: var(--sidebar-expanded-width);
         transform: translateX(-100%);
-        padding-top: calc(var(--header-height) + 1.5rem);
+        padding-top: 1.75rem;
         pointer-events: none;
     }
     body.sidebar-open .app-sidebar {
@@ -1227,7 +1228,7 @@ body:not(.sidebar-open) .sidebar-scroll {
     flex: 1;
     min-height: 0;
     height: 100%;
-    max-height: calc(100vh - 120px); /* Adjusted for new header */
+    max-height: calc(100vh - 120px); /* Keep cards within the viewport */
     overflow: hidden;
     transition: all 0.3s ease;
 }


### PR DESCRIPTION
## Summary
- remove the top header container from the main layout so the sidebar is the only navigation
- add vertical padding to the content area for breathing room after removing the header
- adjust the mobile sidebar offset now that there is no header overlay

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ccdfb1c798832dad9d7d2fec52d54d