### PR TITLE
Make sidebar collapsible with icon-only collapsed view

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
         <script type="module" src="viewer3d.js" defer></script>
     </head>
     <body>
-        <aside id="appSidebar" class="app-sidebar" aria-label="Hauptnavigation">
+        <aside id="appSidebar" class="app-sidebar" aria-label="Hauptnavigation" aria-expanded="false" data-state="collapsed">
             <div class="sidebar-top">
                 <div class="sidebar-brand">
                     <span class="sidebar-logo">MEP</span>

--- a/production.js
+++ b/production.js
@@ -343,6 +343,11 @@ document.addEventListener('DOMContentLoaded', () => {
         const isOpen = document.body.classList.contains('sidebar-open');
         const labelKey = isOpen ? 'Menü einklappen' : 'Menü ausklappen';
         const label = typeof i18n !== 'undefined' ? i18n.t(labelKey) : labelKey;
+        const sidebarElement = document.getElementById('appSidebar');
+        if (sidebarElement) {
+            sidebarElement.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+            sidebarElement.dataset.state = isOpen ? 'expanded' : 'collapsed';
+        }
         document.querySelectorAll('[data-sidebar-toggle]').forEach(toggle => {
             toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
             toggle.setAttribute('aria-label', label);

--- a/styles.css
+++ b/styles.css
@@ -960,7 +960,7 @@ body.sidebar-open .sidebar-toggle svg {
 }
 
 .sidebar-toggle--inline {
-    display: none;
+    display: inline-flex;
 }
 
 .app-sidebar .sidebar-toggle {
@@ -1189,8 +1189,7 @@ body:not(.sidebar-open) .sidebar-submenu-toggle .sidebar-submenu-chevron {
 
 body:not(.sidebar-open) .sidebar-brand-text,
 body:not(.sidebar-open) .sidebar-section-title,
-body:not(.sidebar-open) .sidebar-text,
-body:not(.sidebar-open) .sidebar-footer {
+body:not(.sidebar-open) .sidebar-text {
     display: none;
 }
 
@@ -1199,13 +1198,36 @@ body:not(.sidebar-open) .sidebar-link {
     padding: 0.75rem;
 }
 
-body:not(.sidebar-open) .sidebar-brand,
 body:not(.sidebar-open) .sidebar-top {
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 0.75rem;
+}
+
+body:not(.sidebar-open) .sidebar-toggle--inline {
+    width: 42px;
+    height: 42px;
+}
+
+body:not(.sidebar-open) .sidebar-brand {
     justify-content: center;
 }
 
 body:not(.sidebar-open) .sidebar-scroll {
     padding-right: 0;
+}
+
+body:not(.sidebar-open) .sidebar-footer {
+    align-items: center;
+}
+
+body:not(.sidebar-open) .app-sidebar .app-version {
+    display: none;
+}
+
+body:not(.sidebar-open) .sidebar-link:hover {
+    transform: none;
 }
 
 @media (max-width: 900px) {


### PR DESCRIPTION
## Summary
- expose the sidebar toggle on all screen sizes and adjust the collapsed styling so only navigation icons remain visible
- synchronize the sidebar accessibility state between the markup and runtime logic for assistive technologies

## Testing
- ⚠️ `npm start` *(fails: `serve` CLI is not available in the execution environment)*


------
https://chatgpt.com/codex/tasks/task_e_68ce396319ac832d8735959c7e10eeb7