### PR TITLE
Add 3D dimension labeling for BF2D preview

### DIFF
--- a/bf2d-configurator.js
+++ b/bf2d-configurator.js
@@ -28,6 +28,11 @@
         showLengths: true,
         showRadii: true
     };
+    const preview3dPreferences = {
+        showDimensions: true,
+        showZoneLengths: true,
+        showOverhangs: true
+    };
     const DIMENSION_CONFIG = Object.freeze({
         lengthOffsetPx: 16,
         lengthTextGapPx: 10,
@@ -338,6 +343,33 @@
             radiusToggle.checked = dimensionPreferences.showRadii;
             radiusToggle.addEventListener('change', () => {
                 dimensionPreferences.showRadii = radiusToggle.checked;
+                updateOutputs();
+            });
+        }
+
+        const toggle3dDimensions = document.getElementById('bf2d3dToggleDimensions');
+        if (toggle3dDimensions) {
+            toggle3dDimensions.checked = preview3dPreferences.showDimensions;
+            toggle3dDimensions.addEventListener('change', () => {
+                preview3dPreferences.showDimensions = toggle3dDimensions.checked;
+                updateOutputs();
+            });
+        }
+
+        const toggle3dZoneLengths = document.getElementById('bf2d3dToggleZoneLengths');
+        if (toggle3dZoneLengths) {
+            toggle3dZoneLengths.checked = preview3dPreferences.showZoneLengths;
+            toggle3dZoneLengths.addEventListener('change', () => {
+                preview3dPreferences.showZoneLengths = toggle3dZoneLengths.checked;
+                updateOutputs();
+            });
+        }
+
+        const toggle3dOverhangs = document.getElementById('bf2d3dToggleOverhangs');
+        if (toggle3dOverhangs) {
+            toggle3dOverhangs.checked = preview3dPreferences.showOverhangs;
+            toggle3dOverhangs.addEventListener('change', () => {
+                preview3dPreferences.showOverhangs = toggle3dOverhangs.checked;
                 updateOutputs();
             });
         }
@@ -1537,6 +1569,14 @@
         }
     }
 
+    function get3dDimensionSettings() {
+        return {
+            showDimensions: preview3dPreferences.showDimensions !== false,
+            showZoneLengths: preview3dPreferences.showZoneLengths !== false,
+            showOverhangs: preview3dPreferences.showOverhangs !== false
+        };
+    }
+
     function update3dPreview(summary) {
         const viewer = window.bf2dViewer3D;
         if (!viewer || typeof viewer.update !== 'function') {
@@ -1557,7 +1597,8 @@
             diameter: Number(state.meta.diameter) || 0,
             rollDiameter: Number(state.meta.rollDiameter) || 0,
             pathSegments: Array.isArray(geometry.pathSegments) ? geometry.pathSegments : [],
-            points: Array.isArray(geometry.mathPoints) ? geometry.mathPoints : []
+            points: Array.isArray(geometry.mathPoints) ? geometry.mathPoints : [],
+            dimensionSettings: get3dDimensionSettings()
         });
 
         if (state.viewMode === '3d' && typeof viewer.onResize === 'function') {

--- a/index.html
+++ b/index.html
@@ -731,6 +731,20 @@
                                         <input type="checkbox" id="bf2dShowRadii" checked>
                                         <label for="bf2dShowRadii" data-i18n="Radien anzeigen">Radien anzeigen</label>
                                     </div>
+                                    <div class="bf2d-dimension-toggle-group bf2d-when-3d" role="group" aria-label="Bemaßungen umschalten">
+                                        <label class="bf2d-dimension-toggle">
+                                            <input type="checkbox" id="bf2d3dToggleDimensions" checked>
+                                            <span data-i18n="Maße anzeigen">Maße anzeigen</span>
+                                        </label>
+                                        <label class="bf2d-dimension-toggle">
+                                            <input type="checkbox" id="bf2d3dToggleZoneLengths" checked>
+                                            <span data-i18n="Zonenlängen">Zonenlängen</span>
+                                        </label>
+                                        <label class="bf2d-dimension-toggle">
+                                            <input type="checkbox" id="bf2d3dToggleOverhangs" checked>
+                                            <span data-i18n="Überstände">Überstände</span>
+                                        </label>
+                                    </div>
                                     <div class="bf2d-preview-actions bf2d-when-3d">
                                         <button type="button" id="bf2dReset3dButton" class="btn-secondary" data-i18n="Reset View">Reset View</button>
                                         <button type="button" id="bf2dZoom3dButton" class="btn-secondary" data-i18n="Zoom to Fit">Zoom to Fit</button>

--- a/styles.css
+++ b/styles.css
@@ -3091,6 +3091,21 @@ select.status-select.done {
     color: var(--text-color);
 }
 
+.bf2d-dimension-toggle-group {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.bf2d-dimension-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.85rem;
+    color: var(--muted-text-color, #495057);
+}
+
 .bf2d-view-toggle {
     display: inline-flex;
     border-radius: 999px;
@@ -3184,6 +3199,44 @@ select.status-select.done {
 
 .bf2d-dimensions {
     color: var(--text-color);
+}
+
+#bf2dPreview3d .bf2d-label-layer {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+}
+
+.bf2d-dim-label {
+    font-family: inherit;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: #1f2933;
+    background: rgba(255, 255, 255, 0.92);
+    border: 1px solid rgba(17, 24, 39, 0.12);
+    border-radius: 4px;
+    padding: 2px 6px;
+    white-space: nowrap;
+    box-shadow: 0 2px 6px rgba(15, 23, 42, 0.12);
+}
+
+.bf2d-dim-label--overhang {
+    background: rgba(222, 249, 255, 0.9);
+    border-color: rgba(13, 148, 170, 0.35);
+    color: #055160;
+}
+
+.bf2d-dim-label--arc {
+    background: rgba(232, 245, 233, 0.92);
+    border-color: rgba(25, 135, 84, 0.35);
+    color: #0f5132;
+}
+
+.bf2d-dim-label--total {
+    background: rgba(255, 243, 205, 0.92);
+    border-color: rgba(255, 193, 7, 0.35);
+    color: #856404;
+    font-weight: 600;
 }
 
 .bf2d-dimension-line,


### PR DESCRIPTION
## Summary
- render CSS2D labels in the BF2D 3D viewer with per-segment lengths, overhang detection, and total length text
- add configuration toggles for showing dimensions, zone lengths, and overhangs in the BF2D 3D preview
- style the new toggle group and dimension labels and expose the toggles in the 3D preview toolbar

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cf08c51bcc832dbe1aa9beed6f464e