### PR TITLE
Fix sidebar submenu toggle initialization error

### DIFF
--- a/production.js
+++ b/production.js
@@ -2239,7 +2239,6 @@ function populateResourceForm(resourceId) {
     const minLegInput = form.querySelector('#resourceMinLegLength');
     const maxLegInput = form.querySelector('#resourceMaxLegLength');
     const rollDiametersInput = form.querySelector('#resourceRollDiameters');
-    const rollDiametersInput = form.querySelector('#resourceRollDiameters');
     if (nameInput) nameInput.value = resource.name || '';
     if (descriptionInput) descriptionInput.value = resource.description || '';
     if (minDiameterInput) minDiameterInput.value = resource.minDiameter ?? '';


### PR DESCRIPTION
## Summary
- remove the duplicate rollDiametersInput constant so production.js can parse without throwing
- allow the sidebar submenu toggle logic to run again, restoring the Biegeformen navigation

## Testing
- node --check production.js

------
https://chatgpt.com/codex/tasks/task_e_68d4ed12250c832d92aa3294e5015e17