### PR TITLE
Reorganize generator layout into two columns

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,162 +141,159 @@
         <div class="app-main">
             <main class="app-content">
                 <div id="generatorView" class="app-container">
-                <div class="main-grid">
-                <aside class="input-column">
-                    <div class="card input-card">
-                        <div class="card-header">
-                            <h2 class="card-title" data-i18n="Eingabedaten">Eingabedaten</h2>
-                        </div>
-                        <div class="card-section generator-summary" role="status" aria-live="polite">
-                        <div class="summary-item">
-                            <span class="summary-label" data-i18n="Aktuelle Gesamtlänge">Aktuelle Gesamtlänge</span>
-                            <span class="summary-value" id="summaryTotalLength">0 mm</span>
-                        </div>
-                        <div class="summary-item">
-                            <span class="summary-label" data-i18n="Zonenzähler">Zonenzähler</span>
-                            <span class="summary-value" id="summaryZoneCount">0</span>
-                        </div>
-                        <div class="summary-item">
-                            <span class="summary-label" data-i18n="Summe Bügel">Summe Bügel</span>
-                            <span class="summary-value" id="summaryStirrupCount">0</span>
-                        </div>
-                        <div class="summary-status summary-status--warning" id="summaryStatus" data-i18n="Füge Zonen hinzu, um zu starten.">Füge Zonen hinzu, um zu starten.</div>
-                        </div>
-                        <div class="card-section input-scroll-container">
-                        <h3 class="section-title collapsible-header" data-i18n="Allgemein">Allgemein</h3>
-                        <div class="collapsible-content section-content-bg">
-                            <div class="form-group">
-                                <label for="projekt" data-i18n="Projekt (Hj):">Projekt (Hj):</label>
-                                <input type="text" id="projekt" value="TestProjekt" oninput="triggerPreviewUpdateDebounced()">
+                    <div class="main-grid">
+                        <div class="input-column card">
+                            <div class="card-header">
+                                <h2 class="card-title" data-i18n="Eingabedaten">Eingabedaten</h2>
                             </div>
-                            <div class="form-group">
-                                <label for="KommNr" data-i18n="KommNr (r):">KommNr (r):</label>
-                                <input type="text" id="KommNr" value="A123" oninput="triggerPreviewUpdateDebounced()">
+                            <div class="generator-summary" role="status" aria-live="polite">
+                                <div class="summary-item">
+                                    <span class="summary-label" data-i18n="Aktuelle Gesamtlänge">Aktuelle Gesamtlänge</span>
+                                    <span class="summary-value" id="summaryTotalLength">0 mm</span>
+                                </div>
+                                <div class="summary-item">
+                                    <span class="summary-label" data-i18n="Zonenzähler">Zonenzähler</span>
+                                    <span class="summary-value" id="summaryZoneCount">0</span>
+                                </div>
+                                <div class="summary-item">
+                                    <span class="summary-label" data-i18n="Summe Bügel">Summe Bügel</span>
+                                    <span class="summary-value" id="summaryStirrupCount">0</span>
+                                </div>
+                                <div class="summary-status summary-status--warning" id="summaryStatus" data-i18n="Füge Zonen hinzu, um zu starten.">Füge Zonen hinzu, um zu starten.</div>
                             </div>
-                            <div class="form-group">
-                                <label for="auftrag" data-i18n="Auftrag (i):">Auftrag (i):</label>
-                                <input type="text" id="auftrag" value="Auftrag123" oninput="triggerPreviewUpdateDebounced()">
+                            <div class="input-scroll-container">
+                                <h3 class="section-title collapsible-header" data-i18n="Allgemein">Allgemein</h3>
+                                <div class="collapsible-content section-content-bg">
+                                    <div class="form-group">
+                                        <label for="projekt" data-i18n="Projekt (Hj):">Projekt (Hj):</label>
+                                        <input type="text" id="projekt" value="TestProjekt" oninput="triggerPreviewUpdateDebounced()">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="KommNr" data-i18n="KommNr (r):">KommNr (r):</label>
+                                        <input type="text" id="KommNr" value="A123" oninput="triggerPreviewUpdateDebounced()">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="auftrag" data-i18n="Auftrag (i):">Auftrag (i):</label>
+                                        <input type="text" id="auftrag" value="Auftrag123" oninput="triggerPreviewUpdateDebounced()">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="posnr" data-i18n="Pos.-Nr. (p):">Pos.-Nr. (p):</label>
+                                        <input type="text" id="posnr" value="1" oninput="triggerPreviewUpdateDebounced()">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="gesamtlange" data-i18n="Gesamtlänge (l):">Gesamtlänge (l):</label>
+                                        <input type="number" id="gesamtlange" value="2000" oninput="triggerPreviewUpdateDebounced(); validateNumberInput(this, 1, 'int', 'Gesamtlänge in mm (min. 1)');">
+                                        <span class="input-feedback"></span>
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="anzahl" data-i18n="Anzahl Körbe (n):">Anzahl Körbe (n):</label>
+                                        <input type="number" id="anzahl" value="1" oninput="triggerPreviewUpdateDebounced(); validateNumberInput(this, 1, 'int', 'Anzahl Körbe (min. 1)');">
+                                        <span class="input-feedback"></span>
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="langdrahtDurchmesser" data-i18n="Längsdraht-Ø (d):">Längsdraht-Ø (d):</label>
+                                        <input type="number" id="langdrahtDurchmesser" value="6" oninput="triggerPreviewUpdateDebounced(); validateNumberInput(this, 1, 'int', 'Längsdraht-Ø in mm (min. 1)');">
+                                        <span class="input-feedback"></span>
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="stahlgute" data-i18n="Stahlsorte (g):">Stahlsorte (g):</label>
+                                        <select id="stahlgute" data-masterdata-source="steelGrades" data-masterdata-placeholder-key="Stahlsorte auswählen…" data-masterdata-default="B500B" oninput="triggerPreviewUpdateDebounced()"></select>
+                                    </div>
+                                </div>
+                                <h3 class="section-title collapsible-header" data-i18n="PtGABBIE-Daten">PtGABBIE-Daten</h3>
+                                <div class="collapsible-content section-content-bg">
+                                    <h4 style="font-size: .95rem; font-weight: 600; margin-bottom: .5rem; color: var(--heading-color);" data-i18n="Lagen-Templates">Lagen-Templates</h4>
+                                    <div class="form-group">
+                                        <label for="templateSelect" data-i18n="Template laden:">Template laden:</label>
+                                        <select id="templateSelect" onchange="applyTemplate(this.value)">
+                                            <option value="" data-i18n="Template auswählen…">Template auswählen…</option>
+                                        </select>
+                                    </div>
+                                    <div class="button-group" style="justify-content: flex-end; margin-bottom: 1rem;">
+                                        <button type="button" class="btn-secondary" id="openTemplateManagerButton">
+                                            <svg viewBox="0 0 24 24" style="width: 1.1em; height: 1.1em; margin-right: .5em;">
+                                                <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/>
+                                            </svg>
+                                            <span data-i18n="Templates verwalten">Templates verwalten</span>
+                                        </button>
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="templateName" data-i18n="Korb Template Name:">Korb Template Name:</label>
+                                        <input type="text" id="templateName" placeholder="Neuer Template-Name...">
+                                    </div>
+                                    <div class="button-group" style="justify-content: flex-end;">
+                                        <button type="button" class="btn-secondary" id="saveCurrentTemplateButton">
+                                            <svg viewBox="0 0 24 24">
+                                                <path d="M17 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V7l-4-4zm-5 16c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3zm3-10H5V5h10v4z"></path>
+                                            </svg>
+                                            <span data-i18n="Template speichern">Template speichern</span>
+                                        </button>
+                                        <button type="button" class="btn-secondary" id="downloadTemplatesButton">
+                                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                                                <path d="M19.35 10.04C18.67 6.59 15.64 4 12 4 9.11 4 6.6 5.64 5.35 8.04 2.34 8.36 0 10.91 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96zM17 13l-5 5-5-5h3V9h4v4h3z"/>
+                                            </svg>
+                                            <span data-i18n="Templates herunterladen">Templates herunterladen</span>
+                                        </button>
+                                    </div>
+                                    <span id="templateFeedback" class="info-text" style="text-align: right; margin-top: -.5rem;"></span>
+                                    <hr style="margin: 1rem 0;">
+                                    <div class="form-group">
+                                        <label for="anfangsueberstand" data-i18n="Anfangsüberst. (i):">Anfangsüberst. (i):</label>
+                                        <input type="number" id="anfangsueberstand" value="0" oninput="triggerPreviewUpdateDebounced(); validateNumberInput(this, 0, 'int', 'Anfangsüberstand in mm (min. 0)');">
+                                        <span class="input-feedback"></span>
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="endueberstand" data-i18n="Endüberstand (f):">Endüberstand (f):</label>
+                                        <input type="number" id="endueberstand" value="0" oninput="triggerPreviewUpdateDebounced(); validateNumberInput(this, 0, 'int', 'Endüberstand in mm (min. 0)');">
+                                        <span class="input-feedback"></span>
+                                    </div>
+                                    <h4 style="font-size: .95rem; font-weight: 600; margin-top: 1rem; margin-bottom: .5rem; color: var(--heading-color);" data-i18n="Bügelzonen">Bügelzonen</h4>
+                                    <div class="form-group">
+                                        <label for="maxZonesInput" data-i18n="Max. Zonen">Max. Zonen</label>
+                                        <input type="number" id="maxZonesInput" value="20" min="1" oninput="updateMaxZones(this.value)">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="zonesPerLabelInput" data-i18n="Zonenanzahl Zone 1">Zonenanzahl Zone 1</label>
+                                        <input type="number" id="zonesPerLabelInput" value="16" min="1" oninput="updateZonesPerLabel(this.value)">
+                                    </div>
+                                    <div class="zone-table-wrapper">
+                                        <table id="zonesTable" class="full-width-table">
+                                            <thead>
+                                                <tr>
+                                                    <th style="width: 30px; padding: 0;"></th>
+                                                    <th style="width: 60px;" data-i18n="Bügel Ø">Bügel Ø</th>
+                                                    <th data-i18n="Anzahl">Anzahl</th>
+                                                    <th data-i18n="Abstand mm">Abstand mm</th>
+                                                    <th style="width: 25px;"></th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    <div class="button-group" style="margin-top: .5rem; justify-content: flex-end;">
+                                        <button type="button" class="btn-secondary" id="addZoneButton" style="width: auto;">
+                                            <svg viewBox="0 0 24 24" style="width: 1.1em; height: 1.1em; margin-right: .5em;">
+                                                <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
+                                            </svg>
+                                            <span data-i18n="Neue Zone hinzufügen">Neue Zone hinzufügen</span>
+                                        </button>
+                                    </div>
+                                    <span class="info-text" style="margin-top: .2rem; display: block;" data-i18n="Jede Zone: Durchmesser, Anzahl, Pitch.">Jede Zone: Durchmesser, Anzahl, Pitch.</span>
+                                </div>
                             </div>
-                            <div class="form-group">
-                                <label for="posnr" data-i18n="Pos.-Nr. (p):">Pos.-Nr. (p):</label>
-                                <input type="text" id="posnr" value="1" oninput="triggerPreviewUpdateDebounced()">
-                            </div>
-                            <div class="form-group">
-                                <label for="gesamtlange" data-i18n="Gesamtlänge (l):">Gesamtlänge (l):</label>
-                                <input type="number" id="gesamtlange" value="2000" oninput="triggerPreviewUpdateDebounced(); validateNumberInput(this, 1, 'int', 'Gesamtlänge in mm (min. 1)');">
-                                <span class="input-feedback"></span>
-                            </div>
-                            <div class="form-group">
-                                <label for="anzahl" data-i18n="Anzahl Körbe (n):">Anzahl Körbe (n):</label>
-                                <input type="number" id="anzahl" value="1" oninput="triggerPreviewUpdateDebounced(); validateNumberInput(this, 1, 'int', 'Anzahl Körbe (min. 1)');">
-                                <span class="input-feedback"></span>
-                            </div>
-                            <div class="form-group">
-                                <label for="langdrahtDurchmesser" data-i18n="Längsdraht-Ø (d):">Längsdraht-Ø (d):</label>
-                                <input type="number" id="langdrahtDurchmesser" value="6" oninput="triggerPreviewUpdateDebounced(); validateNumberInput(this, 1, 'int', 'Längsdraht-Ø in mm (min. 1)');">
-                                <span class="input-feedback"></span>
-                            </div>
-                            <div class="form-group">
-                                <label for="stahlgute" data-i18n="Stahlsorte (g):">Stahlsorte (g):</label>
-                                <select id="stahlgute" data-masterdata-source="steelGrades" data-masterdata-placeholder-key="Stahlsorte auswählen…" data-masterdata-default="B500B" oninput="triggerPreviewUpdateDebounced()"></select>
-                            </div>
-                        </div>
-                        <h3 class="section-title collapsible-header" data-i18n="PtGABBIE-Daten">PtGABBIE-Daten</h3>
-                        <div class="collapsible-content section-content-bg">
-                            <h4 style="font-size: .95rem; font-weight: 600; margin-bottom: .5rem; color: var(--heading-color);" data-i18n="Lagen-Templates">Lagen-Templates</h4>
-                            <div class="form-group">
-                                <label for="templateSelect" data-i18n="Template laden:">Template laden:</label>
-                                <select id="templateSelect" onchange="applyTemplate(this.value)">
-                                    <option value="" data-i18n="Template auswählen…">Template auswählen…</option>
-                                </select>
-                            </div>
-                            <div class="button-group" style="justify-content: flex-end; margin-bottom: 1rem;">
-                                <button type="button" class="btn-secondary" id="openTemplateManagerButton">
+                            <div style="margin-top: auto; padding-top: 1rem; background-color: var(--card-bg-color); border-top: 1px solid var(--border-color); z-index: 10; position: sticky; bottom: 0; margin-left: -1rem; margin-right: -1rem; padding-left: 1rem; padding-right: 1rem;">
+                                <button type="button" id="generateButton" style="width: 100%; padding: .75rem 1rem; font-size: 1rem;">
                                     <svg viewBox="0 0 24 24" style="width: 1.1em; height: 1.1em; margin-right: .5em;">
-                                        <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/>
+                                        <path d="M20 8H4V6h16v2zm-2-6H6v2h12V2zm4 10v8c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2v-8c0-1.1.9-2 2-2h16c1.1 0 2 .9 2 2zm-6 4h-4v4h4v-4z"></path>
                                     </svg>
-                                    <span data-i18n="Templates verwalten">Templates verwalten</span>
+                                    <span data-i18n="BVBS Code & Barcode generieren">BVBS Code & Barcode generieren</span>
                                 </button>
+                                <div id="generateError" class="info-text" style="margin-top: .5rem; min-height: 1.2em;"></div>
                             </div>
-                            <div class="form-group">
-                                <label for="templateName" data-i18n="Korb Template Name:">Korb Template Name:</label>
-                                <input type="text" id="templateName" placeholder="Neuer Template-Name...">
-                            </div>
-                            <div class="button-group" style="justify-content: flex-end;">
-                                <button type="button" class="btn-secondary" id="saveCurrentTemplateButton">
-                                    <svg viewBox="0 0 24 24">
-                                        <path d="M17 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V7l-4-4zm-5 16c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3zm3-10H5V5h10v4z"></path>
-                                    </svg>
-                                    <span data-i18n="Template speichern">Template speichern</span>
-                                </button>
-                                <button type="button" class="btn-secondary" id="downloadTemplatesButton">
-                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-                                        <path d="M19.35 10.04C18.67 6.59 15.64 4 12 4 9.11 4 6.6 5.64 5.35 8.04 2.34 8.36 0 10.91 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96zM17 13l-5 5-5-5h3V9h4v4h3z"/>
-                                    </svg>
-                                    <span data-i18n="Templates herunterladen">Templates herunterladen</span>
-                                </button>
-                            </div>
-                            <span id="templateFeedback" class="info-text" style="text-align: right; margin-top: -.5rem;"></span>
-                            <hr style="margin: 1rem 0;">
-                            <div class="form-group">
-                                <label for="anfangsueberstand" data-i18n="Anfangsüberst. (i):">Anfangsüberst. (i):</label>
-                                <input type="number" id="anfangsueberstand" value="0" oninput="triggerPreviewUpdateDebounced(); validateNumberInput(this, 0, 'int', 'Anfangsüberstand in mm (min. 0)');">
-                                <span class="input-feedback"></span>
-                            </div>
-                            <div class="form-group">
-                                <label for="endueberstand" data-i18n="Endüberstand (f):">Endüberstand (f):</label>
-                                <input type="number" id="endueberstand" value="0" oninput="triggerPreviewUpdateDebounced(); validateNumberInput(this, 0, 'int', 'Endüberstand in mm (min. 0)');">
-                                <span class="input-feedback"></span>
-                            </div>
-                            <h4 style="font-size: .95rem; font-weight: 600; margin-top: 1rem; margin-bottom: .5rem; color: var(--heading-color);" data-i18n="Bügelzonen">Bügelzonen</h4>
-                            <div class="form-group">
-                                <label for="maxZonesInput" data-i18n="Max. Zonen">Max. Zonen</label>
-                                <input type="number" id="maxZonesInput" value="20" min="1" oninput="updateMaxZones(this.value)">
-                            </div>
-                            <div class="form-group">
-                                <label for="zonesPerLabelInput" data-i18n="Zonenanzahl Zone 1">Zonenanzahl Zone 1</label>
-                                <input type="number" id="zonesPerLabelInput" value="16" min="1" oninput="updateZonesPerLabel(this.value)">
-                            </div>
-                            <div class="zone-table-wrapper">
-                                <table id="zonesTable" class="full-width-table">
-									<thead>
-										<tr>
-											<th style="width: 30px; padding: 0;"></th>
-											<th style="width: 60px;" data-i18n="Bügel Ø">Bügel Ø</th> 
-											<th data-i18n="Anzahl">Anzahl</th>
-											<th data-i18n="Abstand mm">Abstand mm</th> 
-											<th style="width: 25px;"></th>
-										</tr>
-									</thead>
-									<tbody>
-									</tbody>
-								</table>
-                            </div>
-                            <div class="button-group" style="margin-top: .5rem; justify-content: flex-end;">
-                                <button type="button" class="btn-secondary" id="addZoneButton" style="width: auto;">
-                                    <svg viewBox="0 0 24 24" style="width: 1.1em; height: 1.1em; margin-right: .5em;">
-                                        <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
-                                    </svg>
-                                    <span data-i18n="Neue Zone hinzufügen">Neue Zone hinzufügen</span>
-                                </button>
-                            </div>
-                            <span class="info-text" style="margin-top: .2rem; display: block;" data-i18n="Jede Zone: Durchmesser, Anzahl, Pitch.">Jede Zone: Durchmesser, Anzahl, Pitch.</span>
                         </div>
-                    </div>
-                    <div style="margin-top: auto; padding-top: 1rem; background-color: var(--card-bg-color); border-top: 1px solid var(--border-color); z-index: 10; position: sticky; bottom: 0; margin-left: -1rem; margin-right: -1rem; padding-left: 1rem; padding-right: 1rem;">
-                        <button type="button" id="generateButton" style="width: 100%; padding: .75rem 1rem; font-size: 1rem;">
-                            <svg viewBox="0 0 24 24" style="width: 1.1em; height: 1.1em; margin-right: .5em;">
-                                <path d="M20 8H4V6h16v2zm-2-6H6v2h12V2zm4 10v8c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2v-8c0-1.1.9-2 2-2h16c1.1 0 2 .9 2 2zm-6 4h-4v4h4v-4z"></path>
-                            </svg>
-                            <span data-i18n="BVBS Code & Barcode generieren">BVBS Code & Barcode generieren</span>
-                        </button>
-                        <div id="generateError" class="info-text" style="margin-top: .5rem; min-height: 1.2em;"></div>
-                    </div>
-                        </div>
-                    </div>
-                </aside>
-                <div class="preview-column">
-                    <div class="card preview-card layout-full">
+                        <div class="preview-column">
+                            <div class="card preview-card layout-full">
                         <div class="card-header preview-header">
                             <div class="preview-title">
                                 <h2 class="card-title" data-i18n="Visuelle Vorschau Korb">Visuelle Vorschau Korb</h2>

--- a/styles.css
+++ b/styles.css
@@ -878,8 +878,8 @@ select {
 
 .main-grid {
     display: grid;
-    grid-template-columns: minmax(320px, 380px) minmax(0, 1fr);
-    gap: 1.75rem;
+    grid-template-columns: minmax(360px, 440px) minmax(0, 1fr);
+    gap: 1.5rem;
     align-items: start;
     width: 100%;
 }
@@ -887,26 +887,15 @@ select {
 .input-column {
     display: flex;
     flex-direction: column;
-    position: relative;
+    min-width: 360px;
+    max-width: 440px;
 }
 
-.card-section {
+.input-column .input-scroll-container {
+    flex: 1;
     display: flex;
     flex-direction: column;
-    gap: 1.25rem;
-    min-width: 0;
-}
-
-.input-card {
-    gap: 1.5rem;
-    position: sticky;
-    top: calc(var(--header-height) + 1.5rem);
-    max-height: calc(100vh - var(--header-height) - 3rem);
-    overflow: hidden;
-}
-
-.input-card .input-scroll-container {
-    flex: 1;
+    gap: 1.35rem;
     overflow-y: auto;
     padding-right: 0.5rem;
     margin-right: -0.5rem;
@@ -914,16 +903,16 @@ select {
     scrollbar-width: thin;
 }
 
-.input-card .input-scroll-container::-webkit-scrollbar {
+.input-column .input-scroll-container::-webkit-scrollbar {
     width: 8px;
 }
 
-.input-card .input-scroll-container::-webkit-scrollbar-thumb {
+.input-column .input-scroll-container::-webkit-scrollbar-thumb {
     background-color: rgba(var(--primary-color-rgb), 0.35);
     border-radius: 999px;
 }
 
-.input-card .input-scroll-container::-webkit-scrollbar-track {
+.input-column .input-scroll-container::-webkit-scrollbar-track {
     background-color: transparent;
 }
 
@@ -958,11 +947,11 @@ select {
     .main-grid {
         grid-template-columns: minmax(0, 1fr);
     }
-    .input-card {
-        position: static;
-        max-height: none;
+    .input-column {
+        min-width: 0;
+        max-width: none;
     }
-    .input-card .input-scroll-container {
+    .input-column .input-scroll-container {
         overflow: visible;
         padding-right: 0;
         margin-right: 0;
@@ -1792,19 +1781,6 @@ h3.section-title.collapsed::after {
     margin-top: 0;
 }
 
-.input-scroll-container {
-    display: flex;
-    flex-direction: column;
-    gap: 1.35rem;
-    min-width: 0;
-}
-			.input-scroll-container::-webkit-scrollbar-thumb {
-			background: var(--text-muted-color);
-			border-radius: 10px;
-			}
-			.input-scroll-container::-webkit-scrollbar-thumb:hover {
-			background: var(--secondary-color);
-			}
 			div.zone-item-header {
 			display: flex;
 			justify-content: space-between;


### PR DESCRIPTION
## Summary
- restructure the generator view markup so the input card sits directly in the left column again and the preview stack remains in the right column
- update the two-column grid and scroll styling to match the restored layout and remove the old nested card helpers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4f5533ed4832d8a4285ff5de82b18