### PR TITLE
Refine BF3D layout to span full workspace

### DIFF
--- a/index.html
+++ b/index.html
@@ -804,91 +804,93 @@
                     </div>
                 </div>
 <div id="bf3dView" class="app-container" style="display:none;">
-    <div class="bf2d-layout">
-        <div class="card">
-            <div class="card-header">
-                <h2 class="card-title" data-i18n="BF3D Konfigurator">BF3D Konfigurator</h2>
-            </div>
-            <div class="bf2d-form-grid">
-                <div class="form-group">
-                    <label for="bf3dPosition" data-i18n="Pos.-Nr. (p)">Pos.-Nr. (p)</label>
-                    <input type="text" id="bf3dPosition" value="1">
+    <div class="bf3d-layout">
+        <div class="bf3d-column">
+            <div class="card">
+                <div class="card-header">
+                    <h2 class="card-title" data-i18n="BF3D Konfigurator">BF3D Konfigurator</h2>
+                </div>
+                <div class="bf2d-form-grid">
+                    <div class="form-group">
+                        <label for="bf3dPosition" data-i18n="Pos.-Nr. (p)">Pos.-Nr. (p)</label>
+                        <input type="text" id="bf3dPosition" value="1">
+                    </div>
+                    <div class="form-group">
+                        <label for="bf3dQuantity" data-i18n="Anzahl (n)">Anzahl (n)</label>
+                        <input type="number" id="bf3dQuantity" value="1" min="1">
+                    </div>
+                    <div class="form-group">
+                        <label for="bf3dDiameter" data-i18n="Durchmesser (d)">Durchmesser (d)</label>
+                        <input type="number" id="bf3dDiameter" value="10" min="1">
+                    </div>
+                    <div class="form-group">
+                        <label for="bf3dSteelGrade" data-i18n="Stahlsorte (g)">Stahlsorte (g)</label>
+                        <select id="bf3dSteelGrade" data-masterdata-source="steelGrades" data-masterdata-placeholder-key="Stahlsorte auswählen…" data-masterdata-default="B500B"></select>
+                    </div>
+                    <div class="form-group">
+                        <label for="bf3dBendingRoller" data-i18n="Biegerolle (s)">Biegerolle (s)</label>
+                        <select id="bf3dBendingRoller" data-masterdata-source="rollDiameters" data-masterdata-placeholder-key="Biegerollendurchmesser auswählen…" data-masterdata-default="40"></select>
+                    </div>
+                </div>
+                <div class="card-header">
+                    <h2 class="card-title" data-i18n="Geometrie">Geometrie</h2>
+                </div>
+                <div class="bf2d-segment-table-wrapper">
+                    <table class="full-width-table" id="bf3dPointTable">
+                        <thead>
+                            <tr>
+                                <th data-i18n="Punkt">Punkt</th>
+                                <th data-i18n="X">X</th>
+                                <th data-i18n="Y">Y</th>
+                                <th data-i18n="Z">Z</th>
+                                <th data-i18n="Aktionen">Aktionen</th>
+                            </tr>
+                        </thead>
+                        <tbody id="bf3dPointTableBody"></tbody>
+                    </table>
+                </div>
+                <div class="button-group">
+                    <button type="button" id="bf3dAddPoint" class="btn-secondary" data-i18n="Punkt hinzufügen">Punkt hinzufügen</button>
+                    <button type="button" id="bf3dRemovePoint" class="btn-danger" data-i18n="Punkt löschen" disabled>Punkt löschen</button>
                 </div>
                 <div class="form-group">
-                    <label for="bf3dQuantity" data-i18n="Anzahl (n)">Anzahl (n)</label>
-                    <input type="number" id="bf3dQuantity" value="1" min="1">
+                    <label><input type="checkbox" id="bf3dSnapGrid"> <span data-i18n="Am Raster fangen">Am Raster fangen</span></label>
+                    <input type="number" id="bf3dGridSize" value="10" min="1" style="width: 60px;"> mm
                 </div>
                 <div class="form-group">
-                    <label for="bf3dDiameter" data-i18n="Durchmesser (d)">Durchmesser (d)</label>
-                    <input type="number" id="bf3dDiameter" value="10" min="1">
+                    <label><input type="checkbox" id="bf3dForceIntegers"> <span data-i18n="Ganzzahlen erzwingen">Ganzzahlen erzwingen</span></label>
                 </div>
-                <div class="form-group">
-                    <label for="bf3dSteelGrade" data-i18n="Stahlsorte (g)">Stahlsorte (g)</label>
-                    <select id="bf3dSteelGrade" data-masterdata-source="steelGrades" data-masterdata-placeholder-key="Stahlsorte auswählen…" data-masterdata-default="B500B"></select>
-                </div>
-                <div class="form-group">
-                    <label for="bf3dBendingRoller" data-i18n="Biegerolle (s)">Biegerolle (s)</label>
-                    <select id="bf3dBendingRoller" data-masterdata-source="rollDiameters" data-masterdata-placeholder-key="Biegerollendurchmesser auswählen…" data-masterdata-default="40"></select>
-                </div>
-            </div>
-             <div class="card-header">
-                <h2 class="card-title" data-i18n="Geometrie">Geometrie</h2>
-            </div>
-            <div class="bf2d-segment-table-wrapper">
-                <table class="full-width-table" id="bf3dPointTable">
-                    <thead>
-                        <tr>
-                            <th data-i18n="Punkt">Punkt</th>
-                            <th data-i18n="X">X</th>
-                            <th data-i18n="Y">Y</th>
-                            <th data-i18n="Z">Z</th>
-                            <th data-i18n="Aktionen">Aktionen</th>
-                        </tr>
-                    </thead>
-                    <tbody id="bf3dPointTableBody"></tbody>
-                </table>
-            </div>
-            <div class="button-group">
-                <button type="button" id="bf3dAddPoint" class="btn-secondary" data-i18n="Punkt hinzufügen">Punkt hinzufügen</button>
-                <button type="button" id="bf3dRemovePoint" class="btn-danger" data-i18n="Punkt löschen" disabled>Punkt löschen</button>
-            </div>
-            <div class="form-group">
-                <label><input type="checkbox" id="bf3dSnapGrid"> <span data-i18n="Am Raster fangen">Am Raster fangen</span></label>
-                <input type="number" id="bf3dGridSize" value="10" min="1" style="width: 60px;"> mm
-            </div>
-             <div class="form-group">
-                <label><input type="checkbox" id="bf3dForceIntegers"> <span data-i18n="Ganzzahlen erzwingen">Ganzzahlen erzwingen</span></label>
-            </div>
 
-            <div class="card-header">
-                <h2 class="card-title" data-i18n="Quick-Aktionen">Quick-Aktionen</h2>
-            </div>
-            <div class="button-group">
-                <input type="number" id="bf3dStraightLength" value="100" style="width: 80px;">
-                <select id="bf3dStraightDirection">
-                    <option value="x">X</option>
-                    <option value="y">Y</option>
-                    <option value="z">Z</option>
-                </select>
-                <button type="button" id="bf3dAddStraight" class="btn-secondary" data-i18n="Gerade hinzufügen">Gerade hinzufügen</button>
-            </div>
-            <div class="button-group">
-                <input type="number" id="bf3dArcRadius" value="50" style="width: 80px;">
-                <select id="bf3dArcPlane">
-                    <option value="xy">XY</option>
-                    <option value="yz">YZ</option>
-                    <option value="xz">XZ</option>
-                </select>
-                <select id="bf3dArcDirection" title="Drehrichtung" data-i18n-title="Drehrichtung">
-                    <option value="ccw" data-i18n="Links (CCW)">Links (CCW)</option>
-                    <option value="cw" data-i18n="Rechts (CW)">Rechts (CW)</option>
-                </select>
-                <button type="button" id="bf3dAddArc" class="btn-secondary" data-i18n="90°-Bogen hinzufügen">90°-Bogen hinzufügen</button>
+                <div class="card-header">
+                    <h2 class="card-title" data-i18n="Quick-Aktionen">Quick-Aktionen</h2>
+                </div>
+                <div class="button-group">
+                    <input type="number" id="bf3dStraightLength" value="100" style="width: 80px;">
+                    <select id="bf3dStraightDirection">
+                        <option value="x">X</option>
+                        <option value="y">Y</option>
+                        <option value="z">Z</option>
+                    </select>
+                    <button type="button" id="bf3dAddStraight" class="btn-secondary" data-i18n="Gerade hinzufügen">Gerade hinzufügen</button>
+                </div>
+                <div class="button-group">
+                    <input type="number" id="bf3dArcRadius" value="50" style="width: 80px;">
+                    <select id="bf3dArcPlane">
+                        <option value="xy">XY</option>
+                        <option value="yz">YZ</option>
+                        <option value="xz">XZ</option>
+                    </select>
+                    <select id="bf3dArcDirection" title="Drehrichtung" data-i18n-title="Drehrichtung">
+                        <option value="ccw" data-i18n="Links (CCW)">Links (CCW)</option>
+                        <option value="cw" data-i18n="Rechts (CW)">Rechts (CW)</option>
+                    </select>
+                    <button type="button" id="bf3dAddArc" class="btn-secondary" data-i18n="90°-Bogen hinzufügen">90°-Bogen hinzufügen</button>
+                </div>
             </div>
         </div>
-        <div class="preview-column">
+        <div class="bf3d-column bf3d-column--preview">
             <div class="card preview-card">
-                 <div class="card-header">
+                <div class="card-header">
                     <h2 class="card-title" data-i18n="Vorschau">Vorschau</h2>
                     <div class="bf2d-preview-controls" style="margin-left: auto;">
                         <div class="bf2d-view-toggle" role="group" aria-label="Ansicht umschalten">
@@ -897,25 +899,29 @@
                         </div>
                     </div>
                 </div>
-                    <div class="bfma-preview-container" data-view-mode="2d">
-                        <canvas id="bf3dPreview2d" style="width: 100%; height: 300px;"></canvas>
-                        <div class="bf3d-dimension-toggle-group" aria-label="Bemaßungen umschalten">
-                            <label class="bf3d-dimension-toggle">
-                                <input type="checkbox" id="bf3dToggleDimensions" checked>
-                                <span data-i18n="Maße anzeigen">Maße anzeigen</span>
-                            </label>
-                            <label class="bf3d-dimension-toggle">
-                                <input type="checkbox" id="bf3dToggleZoneLengths" checked>
-                                <span data-i18n="Zonenlängen">Zonenlängen</span>
-                            </label>
-                            <label class="bf3d-dimension-toggle">
-                                <input type="checkbox" id="bf3dToggleOverhangs" checked>
-                                <span data-i18n="Überstände">Überstände</span>
-                            </label>
-                        </div>
-                        <div id="bf3dPreview3d" class="bfma-preview-3d" style="display: none; width: 100%; height: 300px; position: relative;" aria-hidden="true"></div>
+                <div class="bf3d-preview-container" data-view-mode="2d">
+                    <div class="bf3d-preview-stage" role="img" aria-label="BF3D Vorschau">
+                        <canvas id="bf3dPreview2d"></canvas>
+                        <div id="bf3dPreview3d" class="bf3d-preview-3d" style="display: none;" aria-hidden="true"></div>
                     </div>
+                    <div class="bf3d-dimension-toggle-group" aria-label="Bemaßungen umschalten">
+                        <label class="bf3d-dimension-toggle">
+                            <input type="checkbox" id="bf3dToggleDimensions" checked>
+                            <span data-i18n="Maße anzeigen">Maße anzeigen</span>
+                        </label>
+                        <label class="bf3d-dimension-toggle">
+                            <input type="checkbox" id="bf3dToggleZoneLengths" checked>
+                            <span data-i18n="Zonenlängen">Zonenlängen</span>
+                        </label>
+                        <label class="bf3d-dimension-toggle">
+                            <input type="checkbox" id="bf3dToggleOverhangs" checked>
+                            <span data-i18n="Überstände">Überstände</span>
+                        </label>
+                    </div>
+                </div>
             </div>
+        </div>
+        <div class="bf3d-column">
             <div class="card">
                 <div class="card-header">
                     <h2 class="card-title" data-i18n="BVBS-ABS Datensatz">BVBS-ABS Datensatz</h2>

--- a/styles.css
+++ b/styles.css
@@ -144,6 +144,7 @@ body[data-density="compact"] .settings-section {
 }
 body[data-density="compact"] .main-grid,
 body[data-density="compact"] .bf2d-layout,
+body[data-density="compact"] #bf3dView .bf3d-layout,
 body[data-density="compact"] .bfma-layout,
 body[data-density="compact"] .preview-column,
 body[data-density="compact"] .resources-layout {
@@ -3117,6 +3118,80 @@ select.status-select.done {
     grid-auto-flow: row;
 }
 
+#bf3dView .bf3d-layout {
+    display: grid;
+    grid-template-columns: minmax(320px, 380px) minmax(360px, 1fr) minmax(260px, 320px);
+    gap: clamp(1.5rem, 2.5vw, 2.5rem);
+    align-items: start;
+    width: 100%;
+}
+
+#bf3dView .bf3d-column {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1.25rem, 2vw, 1.75rem);
+    min-width: 0;
+}
+
+#bf3dView .bf3d-column > .card {
+    margin: 0;
+}
+
+#bf3dView .bf3d-column--preview .card {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+#bf3dView .bf3d-preview-container {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(0.75rem, 1.5vw, 1.25rem);
+    flex: 1;
+}
+
+#bf3dView .bf3d-preview-stage {
+    position: relative;
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    background: var(--card-bg-color);
+    box-shadow: var(--shadow-sm);
+    overflow: hidden;
+    min-height: clamp(320px, 45vh, 520px);
+}
+
+#bf3dPreview2d,
+#bf3dPreview3d {
+    width: 100%;
+    height: 100%;
+    min-height: clamp(320px, 45vh, 520px);
+    display: block;
+}
+
+#bf3dPreview3d {
+    position: absolute;
+    inset: 0;
+}
+
+#bf3dView .bf3d-dimension-toggle-group {
+    margin: 0;
+    padding-top: 0.75rem;
+    border-top: 1px solid rgba(148, 163, 184, 0.18);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    align-items: center;
+}
+
+#bf3dView .bf3d-dimension-toggle input[type="checkbox"] {
+    width: 1rem;
+    height: 1rem;
+}
+
+#bf3dView .card textarea {
+    width: 100%;
+}
+
 #bf2dView.app-container,
 #bf3dView.app-container,
 #bfmaView.app-container {
@@ -3144,10 +3219,16 @@ body.is-bending-view .app-main {
     .bf2d-layout {
         grid-template-columns: repeat(2, minmax(320px, 1fr));
     }
+    #bf3dView .bf3d-layout {
+        grid-template-columns: repeat(2, minmax(320px, 1fr));
+    }
 }
 
 @media (max-width: 1024px) {
     .bf2d-layout {
+        grid-template-columns: minmax(0, 1fr);
+    }
+    #bf3dView .bf3d-layout {
         grid-template-columns: minmax(0, 1fr);
     }
 }
@@ -3705,6 +3786,19 @@ body[data-theme="dark"] .bf2d-machine-list-item {
 #bf2dDatasetOutput {
     width: 100%;
     min-height: 240px;
+    font-family: 'Fira Code', 'Source Code Pro', monospace;
+    font-size: 0.85rem;
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    padding: 1rem;
+    background: var(--light-bg-color);
+    color: var(--text-color);
+    resize: vertical;
+}
+
+#bf3dDatasetOutput {
+    width: 100%;
+    min-height: 280px;
     font-family: 'Fira Code', 'Source Code Pro', monospace;
     font-size: 0.85rem;
     border: 1px solid var(--border-color);


### PR DESCRIPTION
## Summary
- restructure the BF3D view markup into dedicated layout columns so the configurator, preview, and dataset occupy a full-width three-column grid
- introduce BF3D-specific styling to keep the view aligned with the sidebar, stretch the preview area, and ensure responsive fallbacks
- update dataset styling to match other bending views and keep controls accessible at the top of the page

## Testing
- not run (static changes)


------
https://chatgpt.com/codex/tasks/task_e_68d4faa8f87c832dbffa91e92b14205c