### PR TITLE
Adjust BFMA layout to top-aligned three-column design

### DIFF
--- a/index.html
+++ b/index.html
@@ -934,7 +934,7 @@
 </div>
 <div id="bfmaView" class="app-container" style="display:none;">
     <div class="bfma-layout">
-        <div class="card">
+        <div class="card bfma-config-card">
             <div class="card-header">
                 <h2 class="card-title" data-i18n="BFMA Konfigurator">BFMA Konfigurator</h2>
             </div>
@@ -1092,7 +1092,7 @@
         </div>
 
         <div class="preview-column">
-             <div class="card bf2d-import-card">
+             <div class="card bf2d-import-card bfma-import-card">
                 <div class="card-header">
                     <h2 class="card-title" data-i18n="ABS-Import/Export">ABS-Import/Export</h2>
                 </div>
@@ -1101,7 +1101,7 @@
                 </div>
                 <input type="file" id="bfmaImportFileInput" accept=".abs,text/plain" style="display:none">
             </div>
-            <div class="card preview-card">
+            <div class="card preview-card bfma-preview-card">
                 <div class="card-header">
                     <h2 class="card-title" data-i18n="Vorschau">Vorschau</h2>
                     <div class="bf2d-preview-controls" style="margin-left: auto;">
@@ -1129,7 +1129,7 @@
                     <div id="bfmaPreview3d" class="bfma-preview-3d" style="display: none; width: 100%; height: 400px; position: relative;" aria-hidden="true"></div>
                 </div>
             </div>
-            <div class="card">
+            <div class="card bfma-output-card">
                 <div class="card-header">
                     <h2 class="card-title" data-i18n="BVBS-ABS Datensatz">BVBS-ABS Datensatz</h2>
                 </div>

--- a/styles.css
+++ b/styles.css
@@ -3812,21 +3812,82 @@ body[data-theme="dark"] .bf2d-machine-list-item {
 /* BFMA Konfigurator */
 .bfma-layout {
     display: grid;
-    grid-template-columns: repeat(3, minmax(320px, 1fr));
+    grid-template-columns: minmax(360px, 1.2fr) minmax(320px, 1fr) minmax(320px, 1fr);
     gap: clamp(1.5rem, 2.5vw, 2.5rem);
     align-items: start;
     grid-auto-flow: row;
+}
+
+#bfmaView .bfma-layout > * {
+    margin-bottom: 0;
+}
+
+#bfmaView .bfma-layout > .card {
+    margin-bottom: 0;
+}
+
+#bfmaView .preview-column {
+    display: contents;
+}
+
+#bfmaView .bfma-config-card {
+    grid-column: 1;
+}
+
+#bfmaView .bfma-preview-card {
+    grid-column: 2;
+    grid-row: 1;
+    align-self: stretch;
+}
+
+#bfmaView .bfma-import-card {
+    grid-column: 2;
+    grid-row: 2;
+    align-self: start;
+}
+
+#bfmaView .bfma-output-card {
+    grid-column: 3;
+    grid-row: 1 / span 2;
+    align-self: stretch;
 }
 
 @media (max-width: 1600px) {
     .bfma-layout {
         grid-template-columns: repeat(2, minmax(320px, 1fr));
     }
+
+    #bfmaView .bfma-output-card {
+        grid-column: 2;
+        grid-row: auto;
+    }
 }
 
 @media (max-width: 1024px) {
     .bfma-layout {
         grid-template-columns: minmax(0, 1fr);
+    }
+}
+
+@media (max-width: 1400px) {
+    #bfmaView .bfma-output-card {
+        grid-row: auto;
+    }
+}
+
+@media (max-width: 1200px) {
+    #bfmaView .preview-column {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+        gap: clamp(1.5rem, 2.5vw, 2.5rem);
+    }
+
+    #bfmaView .bfma-config-card,
+    #bfmaView .bfma-preview-card,
+    #bfmaView .bfma-import-card,
+    #bfmaView .bfma-output-card {
+        grid-column: auto;
+        grid-row: auto;
     }
 }
 


### PR DESCRIPTION
## Summary
- tag the Matten configurator and result cards so the BFMA view can be targeted individually
- rework the BFMA layout CSS to create a top-aligned three-column grid that occupies the full width next to the sidebar
- add responsive fallbacks so the layout collapses cleanly on narrower screens

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68d4fca3670c832da2b793da6c3f6ccc