### PR TITLE
Move quick actions to header menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,33 +100,6 @@
                         <span class="sidebar-text" data-i18n="Ressourcen">Ressourcen</span>
                     </button>
                 </nav>
-                <nav class="sidebar-section">
-                    <p class="sidebar-section-title" data-i18n="Schnellaktionen">Schnellaktionen</p>
-                    <button id="quickReleaseButton" class="sidebar-link sidebar-link--action" data-i18n-title="Freigeben" title="Freigeben">
-                        <svg viewBox="0 0 24 24" aria-hidden="true">
-                            <path d="M12 3l7 7h-4v7h-6v-7H5l7-7z" />
-                        </svg>
-                        <span class="sidebar-text" data-i18n="Freigeben">Freigeben</span>
-                    </button>
-                    <button id="quickSavedOrdersButton" class="sidebar-link" data-i18n-title="Gespeicherte Aufträge" title="Gespeicherte Aufträge">
-                        <svg viewBox="0 0 24 24" aria-hidden="true">
-                            <path d="M10 4l2 2h8a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h6z" />
-                        </svg>
-                        <span class="sidebar-text" data-i18n="Gespeicherte Aufträge">Gespeicherte Aufträge</span>
-                    </button>
-                    <button id="quickSvgButton" class="sidebar-link" data-i18n-title="Vorschau als SVG" title="Vorschau als SVG">
-                        <svg viewBox="0 0 24 24" aria-hidden="true">
-                            <path d="M4 5h16v14H4V5zm2 2v10h12V7H6zm3 3h6v6H9z" />
-                        </svg>
-                        <span class="sidebar-text" data-i18n="Vorschau als SVG">Vorschau als SVG</span>
-                    </button>
-                    <button id="quickPrintLabelButton" class="sidebar-link" data-i18n-title="Label drucken" title="Label drucken">
-                        <svg viewBox="0 0 24 24" aria-hidden="true">
-                            <path d="M6 2h12v4H6V2zm12 6H6c-2.21 0-4 1.79-4 4v6h4v4h12v-4h4v-6c0-2.21-1.79-4-4-4zm-2 12H8v-5h8v5z" />
-                        </svg>
-                        <span class="sidebar-text" data-i18n="Label drucken">Label drucken</span>
-                    </button>
-                </div>
             </div>
             <div class="sidebar-footer">
                 <button id="showSettingsBtn" class="sidebar-link sidebar-link--settings" data-view-target="settingsView" data-i18n-title="Einstellungen" title="Einstellungen">
@@ -139,6 +112,48 @@
             </div>
         </aside>
         <div class="app-main">
+            <div class="app-header-wrapper">
+                <header class="app-header" role="banner">
+                    <div class="left-section">
+                        <div class="title-group">
+                            <span class="title-eyebrow">BVBS Suite</span>
+                            <h1 class="app-title" data-i18n="BVBS Korb Generator mit Label-Druck">BVBS Korb Generator mit Label-Druck</h1>
+                            <p class="app-subtitle" data-i18n="Intelligente Werkzeuge für Bewehrungskörbe">Intelligente Werkzeuge für Bewehrungskörbe</p>
+                            <div class="header-badges">
+                                <span class="header-badge" data-i18n="Produktivitätsplattform">Produktivitätsplattform</span>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="right-section">
+                        <nav class="app-header-nav" aria-label="Schnellaktionen">
+                            <button type="button" id="quickReleaseButton" class="header-action header-action--primary" data-i18n-title="Freigeben" title="Freigeben">
+                                <svg viewBox="0 0 24 24" aria-hidden="true">
+                                    <path d="M12 3l7 7h-4v7h-6v-7H5l7-7z" />
+                                </svg>
+                                <span class="header-action-text" data-i18n="Freigeben">Freigeben</span>
+                            </button>
+                            <button type="button" id="quickSavedOrdersButton" class="header-action" data-i18n-title="Gespeicherte Aufträge" title="Gespeicherte Aufträge">
+                                <svg viewBox="0 0 24 24" aria-hidden="true">
+                                    <path d="M10 4l2 2h8a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h6z" />
+                                </svg>
+                                <span class="header-action-text" data-i18n="Gespeicherte Aufträge">Gespeicherte Aufträge</span>
+                            </button>
+                            <button type="button" id="quickSvgButton" class="header-action" data-i18n-title="Vorschau als SVG" title="Vorschau als SVG">
+                                <svg viewBox="0 0 24 24" aria-hidden="true">
+                                    <path d="M4 5h16v14H4V5zm2 2v10h12V7H6zm3 3h6v6H9z" />
+                                </svg>
+                                <span class="header-action-text" data-i18n="Vorschau als SVG">Vorschau als SVG</span>
+                            </button>
+                            <button type="button" id="quickPrintLabelButton" class="header-action" data-i18n-title="Label drucken" title="Label drucken">
+                                <svg viewBox="0 0 24 24" aria-hidden="true">
+                                    <path d="M6 2h12v4H6V2zm12 6H6c-2.21 0-4 1.79-4 4v6h4v4h12v-4h4v-6c0-2.21-1.79-4-4-4zm-2 12H8v-5h8v5z" />
+                                </svg>
+                                <span class="header-action-text" data-i18n="Label drucken">Label drucken</span>
+                            </button>
+                        </nav>
+                    </div>
+                </header>
+            </div>
             <main class="app-content">
                 <div id="generatorView" class="app-container">
                     <div class="main-grid">

--- a/styles.css
+++ b/styles.css
@@ -738,6 +738,64 @@ select {
     flex-wrap: wrap;
 }
 
+.app-header-nav {
+    display: flex;
+    align-items: center;
+    gap: 0.85rem;
+    flex-wrap: wrap;
+}
+
+.header-action {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    padding: 0.65rem 1.1rem;
+    border-radius: 999px;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    background: rgba(15, 23, 42, 0.35);
+    color: var(--header-text-color);
+    font-size: 0.9rem;
+    font-weight: 500;
+    letter-spacing: 0.01em;
+    cursor: pointer;
+    transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease, border-color 0.25s ease;
+    box-shadow: 0 16px 30px rgba(15, 23, 42, 0.45);
+}
+
+.header-action svg {
+    width: 1.1rem;
+    height: 1.1rem;
+    opacity: 0.85;
+    transition: transform 0.25s ease, opacity 0.25s ease;
+}
+
+.header-action:hover {
+    transform: translateY(-2px);
+    background: rgba(15, 23, 42, 0.5);
+    border-color: rgba(226, 232, 240, 0.45);
+    box-shadow: 0 22px 42px rgba(15, 23, 42, 0.55);
+}
+
+.header-action:hover svg {
+    opacity: 1;
+    transform: scale(1.05);
+}
+
+.header-action--primary {
+    background: linear-gradient(135deg, rgba(59, 130, 246, 0.65), rgba(14, 165, 233, 0.55));
+    border-color: rgba(59, 130, 246, 0.75);
+    box-shadow: 0 28px 46px rgba(37, 99, 235, 0.45);
+}
+
+.header-action--primary:hover {
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.75), rgba(59, 130, 246, 0.65));
+    border-color: rgba(191, 219, 254, 0.9);
+}
+
+.header-action-text {
+    white-space: nowrap;
+}
+
 .title-group {
     display: flex;
     flex-direction: column;
@@ -795,6 +853,14 @@ select {
     height: 1px;
     border-radius: 999px;
     background: linear-gradient(90deg, rgba(148, 163, 184, 0), rgba(148, 163, 184, 0.55));
+}
+
+.header-badges {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    margin-top: 0.85rem;
+    flex-wrap: wrap;
 }
 
 .header-badge {
@@ -1658,6 +1724,7 @@ body.sidebar-open .sidebar-overlay {
     .app-header {
         padding: 0.9rem calc(var(--page-side-padding) * 0.55);
         gap: 1.1rem;
+        flex-direction: column;
     }
     .app-header .app-title {
         font-size: 1.4rem;
@@ -1668,8 +1735,25 @@ body.sidebar-open .sidebar-overlay {
     .app-container {
         padding: 0 calc(var(--page-side-padding) * 0.5);
     }
-    .header-badge {
+    .header-badges {
         display: none;
+    }
+    .app-header .left-section {
+        padding-right: 0;
+        border-right: none;
+    }
+    .app-header .right-section {
+        padding-left: 0;
+        justify-content: flex-start;
+        width: 100%;
+    }
+    .app-header-nav {
+        width: 100%;
+        gap: 0.65rem;
+    }
+    .header-action {
+        flex: 1 1 100%;
+        justify-content: center;
     }
 }
 .card {


### PR DESCRIPTION
## Summary
- add a prominent application header that highlights the BVBS Korb Generator and exposes quick actions in a horizontal menu
- remove the Schnellaktionen block from the sidebar and restyle the quick action buttons for the new header layout
- tweak responsive styles so the header content stacks and the quick action buttons remain accessible on smaller screens

## Testing
- no automated tests available

------
https://chatgpt.com/codex/tasks/task_e_68d5001b0094832dbc98cf741c0b4f28