### PR TITLE
Refactor navigation into compact header

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,131 +27,87 @@
         <script src="production.js" defer></script>
         <script type="module" src="viewer3d.js" defer></script>
     </head>
-    <body class="sidebar-open">
-        <aside id="appSidebar" class="app-sidebar" aria-label="Hauptnavigation" aria-expanded="true" data-state="expanded">
-            <div class="sidebar-header">
-                <div class="sidebar-brand">
-                    <span class="sidebar-logo">MEP</span>
-                    <div class="sidebar-brand-meta">
-                        <span class="sidebar-brand-text">BVBS Suite</span>
-                        <span class="sidebar-brand-subtitle">Produktivitätsplattform</span>
-                    </div>
-                </div>
-            </div>
-            <div class="sidebar-scroll">
-                <nav class="sidebar-section">
-                    <p class="sidebar-section-title" data-i18n="Arbeitsbereiche">Arbeitsbereiche</p>
-                    <button id="showGeneratorBtn" class="sidebar-link" data-view-target="generatorView" data-i18n-title="Generator" title="Generator">
-                        <svg viewBox="0 0 24 24" aria-hidden="true">
-                            <path d="M11 21h-1l1-7H5.6L13 3h1l-1 7h6.5L11 21z" />
-                        </svg>
-                        <span class="sidebar-text" data-i18n="Generator">Generator</span>
-                    </button>
-                    <div class="sidebar-submenu" data-submenu data-submenu-views="bf2dView,bf3dView,bfmaView">
-                        <button type="button" class="sidebar-link sidebar-submenu-toggle" data-submenu-toggle aria-expanded="false" data-i18n-title="Biegeformen" title="Biegeformen">
-                            <svg viewBox="0 0 24 24" aria-hidden="true">
-                                <path d="M4 5h8l4 4h4v2h-4l-4-4H4v10H2V5c0-1.1.9-2 2-2h10l4 4h4v2h-4l-4-4H4" />
-                            </svg>
-                            <span class="sidebar-text" data-i18n="Biegeformen">Biegeformen</span>
-                            <svg class="sidebar-submenu-chevron" viewBox="0 0 24 24" aria-hidden="true">
-                                <path d="M9 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-                            </svg>
-                        </button>
-                        <div class="sidebar-submenu-list" data-submenu-list aria-hidden="true">
-                            <button id="showBf2dBtn" class="sidebar-link sidebar-submenu-link" data-view-target="bf2dView" data-i18n-title="Biegeformen 2D" title="Biegeformen 2D">
-                                <svg viewBox="0 0 24 24" aria-hidden="true">
-                                    <path d="M4 5h8l4 4h4v2h-4l-4-4H4v10H2V5c0-1.1.9-2 2-2h10l4 4h4v2h-4l-4-4H4" />
-                                </svg>
-                                <span class="sidebar-text" data-i18n="Biegeformen 2D">Biegeformen 2D</span>
-                            </button>
-                            <button id="showBf3dBtn" class="sidebar-link sidebar-submenu-link" data-view-target="bf3dView" data-i18n-title="Biegeformen 3D" title="Biegeformen 3D">
-                                <svg viewBox="0 0 24 24" aria-hidden="true">
-                                    <path d="M12,7L17,2H7L12,7M12,7L17,12L12,22L7,12L12,7M12,7L2,12L7,17H17L22,12L12,7Z" />
-                                </svg>
-                                <span class="sidebar-text" data-i18n="Biegeformen 3D">Biegeformen 3D</span>
-                            </button>
-                            <button id="showBfmaBtn" class="sidebar-link sidebar-submenu-link" data-view-target="bfmaView" data-i18n-title="Matten" title="Matten">
-                                <svg viewBox="0 0 24 24" aria-hidden="true">
-                                    <path d="M2 2h20v20H2V2zm2 2v16h16V4H4zm2 2h5v5H6V6zm7 0h5v5h-5V6zm-7 7h5v5H6v-5zm7 0h5v5h-5v-5z"/>
-                                </svg>
-                                <span class="sidebar-text" data-i18n="Matten">Matten</span>
-                            </button>
-                        </div>
-                    </div>
-                    <button id="showSavedShapesBtn" class="sidebar-link" data-view-target="savedShapesView" data-i18n-title="Gespeicherte Formen" title="Gespeicherte Formen">
-                        <svg viewBox="0 0 24 24" aria-hidden="true">
-                            <path d="M4 4h6v6H4V4zm10 0h6v6h-6V4zM4 14h6v6H4v-6zm10 0h6v6h-6v-6z" />
-                        </svg>
-                        <span class="sidebar-text" data-i18n="Gespeicherte Formen">Gespeicherte Formen</span>
-                    </button>
-                    <button id="showProductionBtn" class="sidebar-link" data-view-target="productionView" data-i18n-title="Produktion" title="Produktion">
-                        <svg viewBox="0 0 24 24" aria-hidden="true">
-                            <path d="M3 3h18v2H3V3zm0 7h18v2H3v-2zm0 7h18v2H3v-2z" />
-                        </svg>
-                        <span class="sidebar-text" data-i18n="Produktion">Produktion</span>
-                    </button>
-                </nav>
-                <nav class="sidebar-section">
-                    <p class="sidebar-section-title" data-i18n="Stammdaten">Stammdaten</p>
-                    <button id="showResourcesBtn" class="sidebar-link" data-view-target="resourcesView" data-i18n-title="Ressourcen" title="Ressourcen">
-                        <svg viewBox="0 0 24 24" aria-hidden="true">
-                            <path d="M12 3c-4.97 0-9 1.79-9 4v10c0 2.21 4.03 4 9 4s9-1.79 9-4V7c0-2.21-4.03-4-9-4zm0 2c3.86 0 7 1.12 7 2s-3.14 2-7 2-7-1.12-7-2 3.14-2 7-2zm0 14c-3.86 0-7-1.12-7-2v-1.5c1.57 1.1 4.27 1.5 7 1.5s5.43-.4 7-1.5V17c0 .88-3.14 2-7 2zm0-4c-3.86 0-7-1.12-7-2v-1.5c1.57 1.1 4.27 1.5 7 1.5s5.43-.4 7-1.5V13c0 .88-3.14 2-7 2z" />
-                        </svg>
-                        <span class="sidebar-text" data-i18n="Ressourcen">Ressourcen</span>
-                    </button>
-                </nav>
-            </div>
-            <div class="sidebar-footer">
-                <button id="showSettingsBtn" class="sidebar-link sidebar-link--settings" data-view-target="settingsView" data-i18n-title="Einstellungen" title="Einstellungen">
-                    <svg viewBox="0 0 24 24" aria-hidden="true">
-                        <path d="M12 8a4 4 0 1 1 0 8 4 4 0 0 1 0-8zm9 4c0-.7-.08-1.38-.23-2.03l2.02-1.57-1.9-3.3-2.4.74a8.03 8.03 0 0 0-3.5-2.02L14.5 1h-5l-.49 2.82a8.03 8.03 0 0 0-3.5 2.02l-2.4-.74-1.9 3.3 2.02 1.57A8.27 8.27 0 0 0 3 12c0 .7.08 1.38.23 2.03l-2.02 1.57 1.9 3.3 2.4-.74a8.03 8.03 0 0 0 3.5 2.02l.49 2.82h5l.49-2.82a8.03 8.03 0 0 0 3.5-2.02l2.4.74 1.9-3.3-2.02-1.57c.15-.65.23-1.33.23-2.03z" />
-                    </svg>
-                    <span class="sidebar-text" data-i18n="Einstellungen">Einstellungen</span>
-                </button>
-                <div class="app-version">v1.0.0</div>
-            </div>
-        </aside>
+    <body>
         <div class="app-main">
             <div class="app-header-wrapper">
                 <header class="app-header" role="banner">
-                    <div class="left-section">
-                        <div class="title-group">
-                            <span class="title-eyebrow">BVBS Suite</span>
-                            <h1 class="app-title" data-i18n="BVBS Korb Generator mit Label-Druck">BVBS Korb Generator mit Label-Druck</h1>
-                            <p class="app-subtitle" data-i18n="Intelligente Werkzeuge für Bewehrungskörbe">Intelligente Werkzeuge für Bewehrungskörbe</p>
-                            <div class="header-badges">
-                                <span class="header-badge" data-i18n="Produktivitätsplattform">Produktivitätsplattform</span>
+                    <div class="header-top">
+                        <div class="header-brand">
+                            <span class="header-logo">MEP</span>
+                            <div class="title-group">
+                                <span class="title-eyebrow">BVBS Suite</span>
+                                <h1 class="app-title" data-i18n="BVBS Korb Generator mit Label-Druck">BVBS Korb Generator mit Label-Druck</h1>
+                                <p class="app-subtitle" data-i18n="Intelligente Werkzeuge für Bewehrungskörbe">Intelligente Werkzeuge für Bewehrungskörbe</p>
+                                <div class="header-badges">
+                                    <span class="header-badge" data-i18n="Produktivitätsplattform">Produktivitätsplattform</span>
+                                </div>
                             </div>
                         </div>
+                        <span class="header-version">v1.0.0</span>
                     </div>
-                    <div class="right-section">
-                        <nav class="app-header-nav" aria-label="Schnellaktionen">
-                            <button type="button" id="quickReleaseButton" class="header-action header-action--primary" data-i18n-title="Freigeben" title="Freigeben">
+                    <nav class="app-nav" aria-label="Hauptnavigation">
+                        <button id="showGeneratorBtn" class="sidebar-link" data-view-target="generatorView" data-i18n-title="Generator" title="Generator">
+                            <svg viewBox="0 0 24 24" aria-hidden="true">
+                                <path d="M11 21h-1l1-7H5.6L13 3h1l-1 7h6.5L11 21z" />
+                            </svg>
+                            <span class="sidebar-text" data-i18n="Generator">Generator</span>
+                        </button>
+                        <div class="sidebar-submenu" data-submenu data-submenu-views="bf2dView,bf3dView,bfmaView">
+                            <button type="button" class="sidebar-link sidebar-submenu-toggle" data-submenu-toggle aria-expanded="false" data-i18n-title="Biegeformen" title="Biegeformen">
                                 <svg viewBox="0 0 24 24" aria-hidden="true">
-                                    <path d="M12 3l7 7h-4v7h-6v-7H5l7-7z" />
+                                    <path d="M4 5h8l4 4h4v2h-4l-4-4H4v10H2V5c0-1.1.9-2 2-2h10l4 4h4v2h-4l-4-4H4" />
                                 </svg>
-                                <span class="header-action-text" data-i18n="Freigeben">Freigeben</span>
-                            </button>
-                            <button type="button" id="quickSavedOrdersButton" class="header-action" data-i18n-title="Gespeicherte Aufträge" title="Gespeicherte Aufträge">
-                                <svg viewBox="0 0 24 24" aria-hidden="true">
-                                    <path d="M10 4l2 2h8a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h6z" />
+                                <span class="sidebar-text" data-i18n="Biegeformen">Biegeformen</span>
+                                <svg class="sidebar-submenu-chevron" viewBox="0 0 24 24" aria-hidden="true">
+                                    <path d="M9 6l6 6-6 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
                                 </svg>
-                                <span class="header-action-text" data-i18n="Gespeicherte Aufträge">Gespeicherte Aufträge</span>
                             </button>
-                            <button type="button" id="quickSvgButton" class="header-action" data-i18n-title="Vorschau als SVG" title="Vorschau als SVG">
-                                <svg viewBox="0 0 24 24" aria-hidden="true">
-                                    <path d="M4 5h16v14H4V5zm2 2v10h12V7H6zm3 3h6v6H9z" />
-                                </svg>
-                                <span class="header-action-text" data-i18n="Vorschau als SVG">Vorschau als SVG</span>
-                            </button>
-                            <button type="button" id="quickPrintLabelButton" class="header-action" data-i18n-title="Label drucken" title="Label drucken">
-                                <svg viewBox="0 0 24 24" aria-hidden="true">
-                                    <path d="M6 2h12v4H6V2zm12 6H6c-2.21 0-4 1.79-4 4v6h4v4h12v-4h4v-6c0-2.21-1.79-4-4-4zm-2 12H8v-5h8v5z" />
-                                </svg>
-                                <span class="header-action-text" data-i18n="Label drucken">Label drucken</span>
-                            </button>
-                        </nav>
-                    </div>
+                            <div class="sidebar-submenu-list" data-submenu-list aria-hidden="true">
+                                <button id="showBf2dBtn" class="sidebar-link sidebar-submenu-link" data-view-target="bf2dView" data-i18n-title="Biegeformen 2D" title="Biegeformen 2D">
+                                    <svg viewBox="0 0 24 24" aria-hidden="true">
+                                        <path d="M4 5h8l4 4h4v2h-4l-4-4H4v10H2V5c0-1.1.9-2 2-2h10l4 4h4v2h-4l-4-4H4" />
+                                    </svg>
+                                    <span class="sidebar-text" data-i18n="Biegeformen 2D">Biegeformen 2D</span>
+                                </button>
+                                <button id="showBf3dBtn" class="sidebar-link sidebar-submenu-link" data-view-target="bf3dView" data-i18n-title="Biegeformen 3D" title="Biegeformen 3D">
+                                    <svg viewBox="0 0 24 24" aria-hidden="true">
+                                        <path d="M12,7L17,2H7L12,7M12,7L17,12L12,22L7,12L12,7M12,7L2,12L7,17H17L22,12L12,7Z" />
+                                    </svg>
+                                    <span class="sidebar-text" data-i18n="Biegeformen 3D">Biegeformen 3D</span>
+                                </button>
+                                <button id="showBfmaBtn" class="sidebar-link sidebar-submenu-link" data-view-target="bfmaView" data-i18n-title="Matten" title="Matten">
+                                    <svg viewBox="0 0 24 24" aria-hidden="true">
+                                        <path d="M2 2h20v20H2V2zm2 2v16h16V4H4zm2 2h5v5H6V6zm7 0h5v5h-5V6zm-7 7h5v5H6v-5zm7 0h5v5h-5v-5z"/>
+                                    </svg>
+                                    <span class="sidebar-text" data-i18n="Matten">Matten</span>
+                                </button>
+                            </div>
+                        </div>
+                        <button id="showSavedShapesBtn" class="sidebar-link" data-view-target="savedShapesView" data-i18n-title="Gespeicherte Formen" title="Gespeicherte Formen">
+                            <svg viewBox="0 0 24 24" aria-hidden="true">
+                                <path d="M4 4h6v6H4V4zm10 0h6v6h-6V4zM4 14h6v6H4v-6zm10 0h6v6h-6v-6z" />
+                            </svg>
+                            <span class="sidebar-text" data-i18n="Gespeicherte Formen">Gespeicherte Formen</span>
+                        </button>
+                        <button id="showProductionBtn" class="sidebar-link" data-view-target="productionView" data-i18n-title="Produktion" title="Produktion">
+                            <svg viewBox="0 0 24 24" aria-hidden="true">
+                                <path d="M3 3h18v2H3V3zm0 7h18v2H3v-2zm0 7h18v2H3v-2z" />
+                            </svg>
+                            <span class="sidebar-text" data-i18n="Produktion">Produktion</span>
+                        </button>
+                        <button id="showResourcesBtn" class="sidebar-link" data-view-target="resourcesView" data-i18n-title="Ressourcen" title="Ressourcen">
+                            <svg viewBox="0 0 24 24" aria-hidden="true">
+                                <path d="M12 3c-4.97 0-9 1.79-9 4v10c0 2.21 4.03 4 9 4s9-1.79 9-4V7c0-2.21-4.03-4-9-4zm0 2c3.86 0 7 1.12 7 2s-3.14 2-7 2-7-1.12-7-2 3.14-2 7-2zm0 14c-3.86 0-7-1.12-7-2v-1.5c1.57 1.1 4.27 1.5 7 1.5s5.43-.4 7-1.5V17c0 .88-3.14 2-7 2zm0-4c-3.86 0-7-1.12-7-2v-1.5c1.57 1.1 4.27 1.5 7 1.5s5.43-.4 7-1.5V13c0 .88-3.14 2-7 2z" />
+                            </svg>
+                            <span class="sidebar-text" data-i18n="Ressourcen">Ressourcen</span>
+                        </button>
+                        <button id="showSettingsBtn" class="sidebar-link sidebar-link--settings" data-view-target="settingsView" data-i18n-title="Einstellungen" title="Einstellungen">
+                            <svg viewBox="0 0 24 24" aria-hidden="true">
+                                <path d="M12 8a4 4 0 1 1 0 8 4 4 0 0 1 0-8zm9 4c0-.7-.08-1.38-.23-2.03l2.02-1.57-1.9-3.3-2.4.74a8.03 8.03 0 0 0-3.5-2.02L14.5 1h-5l-.49 2.82a8.03 8.03 0 0 0-3.5 2.02l-2.4-.74-1.9 3.3 2.02 1.57A8.27 8.27 0 0 0 3 12c0 .7.08 1.38.23 2.03l-2.02 1.57 1.9 3.3 2.4-.74a8.03 8.03 0 0 0 3.5 2.02l.49 2.82h5l.49-2.82a8.03 8.03 0 0 0 3.5-2.02l2.4.74 1.9-3.3-2.02-1.57c.15-.65.23-1.33.23-2.03z" />
+                            </svg>
+                            <span class="sidebar-text" data-i18n="Einstellungen">Einstellungen</span>
+                        </button>
+                    </nav>
                 </header>
             </div>
             <main class="app-content">

--- a/styles.css
+++ b/styles.css
@@ -75,7 +75,7 @@
     --primary-color-rgb: 74, 144, 226;
 }
 body {
-    --sidebar-width: var(--sidebar-collapsed-width);
+    --sidebar-width: 0px;
     font-family: var(--font-family-sans-serif);
     margin: 0;
     background-color: var(--body-bg-color);
@@ -132,7 +132,7 @@ body[data-density="compact"] .form-group {
 }
 
 body[data-density="compact"] .sidebar-link {
-    padding: 0.65rem 0.85rem;
+    padding: 0.4rem 0.7rem;
 }
 
 body[data-density="compact"] .settings-toggle {
@@ -234,7 +234,7 @@ body[data-motion="reduced"] *::after {
 }
 
 body.sidebar-open {
-    --sidebar-width: var(--sidebar-expanded-width);
+    --sidebar-width: 0px;
 }
 			button,
 			.btn {
@@ -654,29 +654,29 @@ select {
 			justify-content: flex-start;
 			}
 .app-main {
-    margin-left: var(--sidebar-width);
+    margin-left: 0;
     transition: margin-left 0.35s ease;
     min-height: 100vh;
     display: flex;
     flex-direction: column;
     background: var(--body-bg-color);
     position: relative;
-    padding: 2rem 0 2.5rem;
+    padding: 1.5rem 0 2rem;
 }
 
 .app-header-wrapper {
     width: 100%;
-    padding: 1.35rem 0 1.85rem;
+    padding: 1rem 0 1.5rem;
     background: linear-gradient(135deg, var(--header-gradient-start), var(--header-gradient-end));
     color: var(--header-text-color);
-    box-shadow: 0 28px 54px rgba(15, 23, 42, 0.45);
-    margin-bottom: 2.5rem;
+    box-shadow: 0 24px 48px rgba(15, 23, 42, 0.4);
+    margin-bottom: 1.75rem;
     position: sticky;
     top: 0;
     z-index: 1400;
     box-sizing: border-box;
     backdrop-filter: blur(14px);
-    border-bottom: 1px solid rgba(148, 163, 184, 0.22);
+    border-bottom: 1px solid rgba(148, 163, 184, 0.2);
     overflow: hidden;
     isolation: isolate;
 }
@@ -686,9 +686,9 @@ select {
     position: absolute;
     inset: 0;
     background:
-        radial-gradient(circle at left 20%, rgba(59, 130, 246, 0.32), transparent 58%),
-        radial-gradient(circle at right 70%, rgba(14, 165, 233, 0.22), transparent 55%);
-    opacity: 0.9;
+        radial-gradient(circle at left 20%, rgba(59, 130, 246, 0.28), transparent 58%),
+        radial-gradient(circle at right 70%, rgba(14, 165, 233, 0.18), transparent 55%);
+    opacity: 0.85;
     pointer-events: none;
     z-index: 0;
 }
@@ -698,108 +698,75 @@ select {
     max-width: var(--page-content-max-pixel-width);
     margin: 0 auto;
     display: flex;
-    flex-wrap: wrap;
-    align-items: stretch;
-    justify-content: space-between;
-    gap: 1.5rem;
-    min-height: var(--header-height);
-    padding: 1.15rem var(--page-side-padding);
+    flex-direction: column;
+    gap: 1.15rem;
+    padding: 1.1rem var(--page-side-padding) 1.25rem;
     box-sizing: border-box;
     position: relative;
-    border-radius: 24px;
+    border-radius: 20px;
     border: 1px solid rgba(148, 163, 184, 0.22);
     background:
-        linear-gradient(135deg, rgba(15, 23, 42, 0.62), rgba(30, 41, 59, 0.45)),
-        linear-gradient(120deg, rgba(59, 130, 246, 0.18), rgba(14, 165, 233, 0.12));
-    box-shadow: 0 36px 68px rgba(15, 23, 42, 0.5);
+        linear-gradient(135deg, rgba(15, 23, 42, 0.6), rgba(30, 41, 59, 0.48)),
+        linear-gradient(120deg, rgba(59, 130, 246, 0.16), rgba(14, 165, 233, 0.1));
+    box-shadow: 0 28px 52px rgba(15, 23, 42, 0.45);
     backdrop-filter: blur(18px);
     z-index: 1;
 }
 
-.app-header .left-section,
-.app-header .right-section {
+.header-top {
     display: flex;
     align-items: center;
-    gap: 1.35rem;
-    align-self: stretch;
+    justify-content: space-between;
+    gap: 1.25rem;
+    flex-wrap: wrap;
 }
 
-.app-header .left-section {
-    flex: 1 1 280px;
+.header-brand {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex: 1 1 auto;
     min-width: 0;
-    padding-right: 1.5rem;
-    border-right: 1px solid rgba(148, 163, 184, 0.16);
 }
 
-.app-header .right-section {
-    flex: 0 0 auto;
-    padding-left: 1.5rem;
-    justify-content: flex-end;
-    flex-wrap: wrap;
-}
-
-.app-header-nav {
-    display: flex;
-    align-items: center;
-    gap: 0.85rem;
-    flex-wrap: wrap;
-}
-
-.header-action {
+.header-logo {
     display: inline-flex;
     align-items: center;
-    gap: 0.55rem;
-    padding: 0.65rem 1.1rem;
-    border-radius: 999px;
-    border: 1px solid rgba(148, 163, 184, 0.35);
-    background: rgba(15, 23, 42, 0.35);
-    color: var(--header-text-color);
-    font-size: 0.9rem;
-    font-weight: 500;
-    letter-spacing: 0.01em;
-    cursor: pointer;
-    transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease, border-color 0.25s ease;
-    box-shadow: 0 16px 30px rgba(15, 23, 42, 0.45);
+    justify-content: center;
+    width: 42px;
+    height: 42px;
+    border-radius: 14px;
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.45), rgba(59, 130, 246, 0.4));
+    color: #ffffff;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    box-shadow: 0 18px 32px rgba(15, 23, 42, 0.45);
 }
 
-.header-action svg {
-    width: 1.1rem;
-    height: 1.1rem;
-    opacity: 0.85;
-    transition: transform 0.25s ease, opacity 0.25s ease;
-}
-
-.header-action:hover {
-    transform: translateY(-2px);
-    background: rgba(15, 23, 42, 0.5);
-    border-color: rgba(226, 232, 240, 0.45);
-    box-shadow: 0 22px 42px rgba(15, 23, 42, 0.55);
-}
-
-.header-action:hover svg {
-    opacity: 1;
-    transform: scale(1.05);
-}
-
-.header-action--primary {
-    background: linear-gradient(135deg, rgba(59, 130, 246, 0.65), rgba(14, 165, 233, 0.55));
-    border-color: rgba(59, 130, 246, 0.75);
-    box-shadow: 0 28px 46px rgba(37, 99, 235, 0.45);
-}
-
-.header-action--primary:hover {
-    background: linear-gradient(135deg, rgba(37, 99, 235, 0.75), rgba(59, 130, 246, 0.65));
-    border-color: rgba(191, 219, 254, 0.9);
-}
-
-.header-action-text {
+.header-version {
+    font-size: 0.75rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--header-subtext-color);
+    font-weight: 600;
     white-space: nowrap;
+}
+
+.app-nav {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    flex-wrap: wrap;
+    position: relative;
+    z-index: 2;
 }
 
 .title-group {
     display: flex;
     flex-direction: column;
-    gap: 0.45rem;
+    gap: 0.35rem;
     min-width: 0;
 }
 
@@ -858,8 +825,8 @@ select {
 .header-badges {
     display: flex;
     align-items: center;
-    gap: 0.65rem;
-    margin-top: 0.85rem;
+    gap: 0.5rem;
+    margin-top: 0.55rem;
     flex-wrap: wrap;
 }
 
@@ -1447,160 +1414,132 @@ body.sidebar-open .sidebar-toggle--floating {
 .sidebar-link {
     display: inline-flex;
     align-items: center;
-    gap: 0.9rem;
-    padding: 0.85rem 1.1rem;
-    border-radius: 18px;
-    border: 1px solid transparent;
-    background: rgba(15, 23, 42, 0.12);
-    color: inherit;
-    font-size: 0.95rem;
+    gap: 0.6rem;
+    padding: 0.45rem 0.85rem;
+    border-radius: 12px;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    background: rgba(15, 23, 42, 0.32);
+    color: var(--header-text-color);
+    font-size: 0.9rem;
+    font-weight: 500;
+    letter-spacing: 0.01em;
     cursor: pointer;
-    transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease, color 0.3s ease;
+    transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
     position: relative;
-    text-align: left;
+    white-space: nowrap;
 }
 
 .sidebar-link::before {
-    content: "";
-    position: absolute;
-    inset: 2px;
-    border-radius: 16px;
-    background: linear-gradient(135deg, rgba(37, 99, 235, 0.22), rgba(59, 130, 246, 0.15));
-    opacity: 0;
-    transform: scale(0.98);
-    transition: opacity 0.3s ease, transform 0.3s ease;
-    z-index: -1;
+    content: none;
 }
 
 .sidebar-link svg {
-    width: 1.25rem;
-    height: 1.25rem;
+    width: 1.05rem;
+    height: 1.05rem;
     opacity: 0.85;
-    transition: transform 0.3s ease, opacity 0.3s ease;
+    transition: opacity 0.2s ease, transform 0.2s ease;
 }
 
 .sidebar-link:hover {
-    transform: translateX(8px);
-    box-shadow: 0 22px 42px rgba(15, 23, 42, 0.4);
-    background: rgba(15, 23, 42, 0.18);
+    background: rgba(15, 23, 42, 0.45);
+    border-color: rgba(226, 232, 240, 0.4);
+    box-shadow: 0 16px 26px rgba(15, 23, 42, 0.45);
+    transform: translateY(-2px);
 }
 
-.sidebar-link:hover::before {
+.sidebar-link:hover svg {
     opacity: 1;
-    transform: scale(1);
+    transform: scale(1.05);
 }
 
 .sidebar-link.active {
-    background: linear-gradient(135deg, rgba(37, 99, 235, 0.75), rgba(79, 70, 229, 0.65));
+    background: linear-gradient(135deg, rgba(59, 130, 246, 0.68), rgba(14, 165, 233, 0.55));
     color: #ffffff;
-    box-shadow: 0 26px 48px rgba(37, 99, 235, 0.35);
-    border-color: rgba(59, 130, 246, 0.3);
+    border-color: rgba(148, 197, 255, 0.65);
+    box-shadow: 0 20px 32px rgba(37, 99, 235, 0.45);
 }
 
-.sidebar-link.active::before {
+.sidebar-link.active svg {
     opacity: 1;
-    background: linear-gradient(135deg, rgba(37, 99, 235, 0.45), rgba(79, 70, 229, 0.4));
-}
-
-.sidebar-link--action {
-    background: linear-gradient(135deg, rgba(94, 234, 212, 0.18), rgba(45, 212, 191, 0.2));
-}
-
-.sidebar-link--action:hover {
-    background: linear-gradient(135deg, rgba(94, 234, 212, 0.28), rgba(45, 212, 191, 0.3));
 }
 
 .sidebar-link--settings {
-    background: rgba(148, 163, 184, 0.12);
-}
-
-.sidebar-link--settings:hover {
-    background: rgba(148, 163, 184, 0.18);
+    border-color: rgba(148, 163, 184, 0.28);
 }
 
 .sidebar-submenu {
-    border-radius: 18px;
-    background: rgba(15, 23, 42, 0.28);
-    padding: 0.55rem;
-    border: 1px solid rgba(148, 163, 184, 0.18);
+    position: relative;
     display: flex;
-    flex-direction: column;
-    gap: 0.45rem;
+    flex: 0 0 auto;
 }
 
 .sidebar-submenu-toggle {
-    width: 100%;
+    position: relative;
     display: inline-flex;
     align-items: center;
-    gap: 0.85rem;
-    padding: 0.8rem 1rem;
-    border-radius: 16px;
-    border: 1px solid transparent;
-    background: rgba(15, 23, 42, 0.18);
-    cursor: pointer;
-    transition: transform 0.3s ease, background 0.3s ease, box-shadow 0.3s ease;
-}
-
-.sidebar-submenu-toggle:hover {
-    transform: translateX(4px);
-    background: rgba(148, 163, 184, 0.2);
+    gap: 0.6rem;
+    padding-right: 2.2rem;
+    width: auto;
 }
 
 .sidebar-submenu-chevron {
-    width: 1.15rem;
-    height: 1.15rem;
-    margin-left: auto;
-    transition: transform 0.3s ease, opacity 0.3s ease;
+    position: absolute;
+    right: 0.75rem;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 0.85rem;
+    height: 0.85rem;
+    pointer-events: none;
     opacity: 0.7;
+    transition: transform 0.2s ease, opacity 0.2s ease;
 }
 
-.sidebar-submenu.is-open .sidebar-submenu-chevron {
-    transform: rotate(90deg);
+.sidebar-submenu.is-open .sidebar-submenu-chevron,
+.sidebar-submenu-toggle[aria-expanded="true"] .sidebar-submenu-chevron {
+    transform: translateY(-50%) rotate(90deg);
     opacity: 1;
 }
 
 .sidebar-submenu-list {
+    position: absolute;
+    top: calc(100% + 0.4rem);
+    left: 0;
     display: flex;
     flex-direction: column;
-    gap: 0.4rem;
-    padding-left: 0.35rem;
+    gap: 0.35rem;
+    padding: 0.45rem;
     margin: 0;
-    max-height: 0;
-    overflow: hidden;
+    border-radius: 14px;
+    background: rgba(10, 18, 31, 0.95);
+    border: 1px solid rgba(148, 163, 184, 0.3);
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.55);
+    min-width: 220px;
+    z-index: 5;
     opacity: 0;
     transform: translateY(-6px);
-    transition: max-height 0.35s ease, opacity 0.3s ease, transform 0.35s ease;
+    transition: opacity 0.2s ease, transform 0.2s ease;
 }
 
-.sidebar-submenu.is-open .sidebar-submenu-list {
-    max-height: 600px;
+.sidebar-submenu-list[aria-hidden="true"] {
+    opacity: 0;
+    transform: translateY(-6px);
+    pointer-events: none;
+}
+
+.sidebar-submenu-list[aria-hidden="false"] {
     opacity: 1;
     transform: translateY(0);
+    pointer-events: auto;
 }
 
 .sidebar-submenu-link {
-    padding-left: 2.8rem;
-    font-size: 0.92rem;
-    gap: 0.6rem;
-}
-
-.sidebar-footer {
-    display: flex;
-    flex-direction: column;
-    gap: 0.9rem;
-}
-
-.app-sidebar .app-version {
-    font-size: 0.7rem;
-    letter-spacing: 0.22em;
-    text-transform: uppercase;
-    color: var(--sidebar-muted-color);
+    width: 100%;
+    justify-content: flex-start;
+    white-space: nowrap;
 }
 
 .sidebar-text {
-    white-space: normal;
-    overflow: visible;
-    text-overflow: initial;
+    white-space: nowrap;
     font-weight: 500;
     letter-spacing: 0.01em;
 }


### PR DESCRIPTION
## Summary
- remove the standalone sidebar and quick action buttons
- move the navigation into a compact header layout with a built-in version tag
- refresh navigation styles for the dropdown menu and compact density handling

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d5022e202c832d85df1451e52c5927