### PR TITLE
Simplify header to navbar and improve contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,20 +31,6 @@
         <div class="app-main">
             <div class="app-header-wrapper">
                 <header class="app-header" role="banner">
-                    <div class="header-top">
-                        <div class="header-brand">
-                            <span class="header-logo">MEP</span>
-                            <div class="title-group">
-                                <span class="title-eyebrow">BVBS Suite</span>
-                                <h1 class="app-title" data-i18n="BVBS Korb Generator mit Label-Druck">BVBS Korb Generator mit Label-Druck</h1>
-                                <p class="app-subtitle" data-i18n="Intelligente Werkzeuge für Bewehrungskörbe">Intelligente Werkzeuge für Bewehrungskörbe</p>
-                                <div class="header-badges">
-                                    <span class="header-badge" data-i18n="Produktivitätsplattform">Produktivitätsplattform</span>
-                                </div>
-                            </div>
-                        </div>
-                        <span class="header-version">v1.0.0</span>
-                    </div>
                     <nav class="app-nav" aria-label="Hauptnavigation">
                         <button id="showGeneratorBtn" class="sidebar-link" data-view-target="generatorView" data-i18n-title="Generator" title="Generator">
                             <svg viewBox="0 0 24 24" aria-hidden="true">

--- a/styles.css
+++ b/styles.css
@@ -103,7 +103,7 @@ body[data-theme="dark"] {
 }
 
 body[data-theme="dark"] .app-header {
-    background: linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(30, 41, 59, 0.92));
+    background: transparent;
 }
 
 body[data-theme="dark"] .card {
@@ -666,7 +666,7 @@ select {
 
 .app-header-wrapper {
     width: 100%;
-    padding: 1rem 0 1.5rem;
+    padding: 0;
     background: linear-gradient(135deg, var(--header-gradient-start), var(--header-gradient-end));
     color: var(--header-text-color);
     box-shadow: 0 24px 48px rgba(15, 23, 42, 0.4);
@@ -695,21 +695,17 @@ select {
 
 .app-header {
     width: 100%;
-    max-width: var(--page-content-max-pixel-width);
-    margin: 0 auto;
-    display: flex;
-    flex-direction: column;
-    gap: 1.15rem;
-    padding: 1.1rem var(--page-side-padding) 1.25rem;
+    margin: 0;
+    padding: 0;
     box-sizing: border-box;
     position: relative;
-    border-radius: 20px;
-    border: 1px solid rgba(148, 163, 184, 0.22);
-    background:
-        linear-gradient(135deg, rgba(15, 23, 42, 0.6), rgba(30, 41, 59, 0.48)),
-        linear-gradient(120deg, rgba(59, 130, 246, 0.16), rgba(14, 165, 233, 0.1));
-    box-shadow: 0 28px 52px rgba(15, 23, 42, 0.45);
-    backdrop-filter: blur(18px);
+    background: transparent;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+    backdrop-filter: none;
+    display: flex;
+    justify-content: center;
     z-index: 1;
 }
 
@@ -755,19 +751,19 @@ select {
 }
 
 .app-nav {
-    display: inline-flex;
+    display: flex;
     align-items: center;
     justify-content: center;
-    gap: 0.35rem;
-    padding: 0.35rem;
-    border-radius: 999px;
-    background: rgba(226, 232, 240, 0.18);
-    border: 1px solid rgba(148, 163, 184, 0.4);
-    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08), 0 18px 32px rgba(15, 23, 42, 0.28);
+    gap: 0.5rem;
+    width: 100%;
+    padding: 1rem var(--page-side-padding);
+    border-radius: 0;
+    background: transparent;
+    border: none;
+    box-shadow: none;
     position: relative;
     z-index: 2;
     flex-wrap: wrap;
-    backdrop-filter: blur(12px);
 }
 
 .title-group {
@@ -1427,7 +1423,7 @@ body.sidebar-open .sidebar-toggle--floating {
     border-radius: 999px;
     border: none;
     background: transparent;
-    color: rgba(30, 41, 59, 0.75);
+    color: rgba(255, 255, 255, 0.9);
     font-size: 0.85rem;
     font-weight: 600;
     letter-spacing: 0.02em;
@@ -1450,18 +1446,18 @@ body.sidebar-open .sidebar-toggle--floating {
 }
 
 .sidebar-link:hover {
-    background: rgba(255, 255, 255, 0.45);
-    color: #0f172a;
+    background: rgba(255, 255, 255, 0.18);
+    color: #ffffff;
 }
 
 .sidebar-link.active {
-    background: #f8fafc;
-    color: #0f172a;
-    box-shadow: 0 4px 12px rgba(15, 23, 42, 0.18);
+    background: rgba(255, 255, 255, 0.28);
+    color: #ffffff;
+    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.4);
 }
 
 .sidebar-link--settings {
-    color: rgba(30, 41, 59, 0.7);
+    color: rgba(255, 255, 255, 0.8);
 }
 
 .sidebar-submenu {


### PR DESCRIPTION
## Summary
- remove the hero/header metadata so that only the navigation remains
- make the navigation bar span the full width of the page without the previous card styling
- boost contrast for the navigation links with white default, hover, and active states

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68d506c04118832dbe039b021fd906d6