### PR TITLE
Fix header spacing and submenu overflow

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -661,7 +661,7 @@ select {
     flex-direction: column;
     background: var(--body-bg-color);
     position: relative;
-    padding: 1.5rem 0 2rem;
+    padding: 0 0 2rem;
 }
 
 .app-header-wrapper {
@@ -677,7 +677,7 @@ select {
     box-sizing: border-box;
     backdrop-filter: blur(14px);
     border-bottom: 1px solid rgba(148, 163, 184, 0.2);
-    overflow: hidden;
+    overflow: visible;
     isolation: isolate;
 }
 


### PR DESCRIPTION
## Summary
- remove the extra top padding from the main layout so the header sits flush without a white strip
- allow the sticky header wrapper to overflow so the Biegeformen dropdown menu is no longer clipped

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d508dc0a7c832daa67604107e380c7