### PR TITLE
Fix layout spacing for non-generator views

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
         <script src="production.js" defer></script>
         <script type="module" src="viewer3d.js" defer></script>
     </head>
-    <body>
+    <body class="is-generator-view">
         <div class="app-main">
             <div class="app-header-wrapper">
                 <header class="app-header" role="banner">

--- a/production.js
+++ b/production.js
@@ -1646,6 +1646,7 @@ function showView(view) {
         } else {
             document.body.classList.remove('is-bending-view');
         }
+        document.body.classList.toggle('is-generator-view', view === 'generatorView');
     }
     const mainElement = document.querySelector('.app-main');
     if (mainElement && typeof mainElement.scrollTo === 'function') {

--- a/styles.css
+++ b/styles.css
@@ -664,6 +664,15 @@ select {
     padding: 0 0 2rem;
 }
 
+body:not(.is-generator-view) .app-content {
+    display: none;
+}
+
+body:not(.is-generator-view) .app-main {
+    min-height: auto;
+    padding-bottom: 0;
+}
+
 .app-header-wrapper {
     width: 100%;
     padding: 0;
@@ -3248,6 +3257,10 @@ select.status-select.done {
 body.is-bending-view .app-main {
     padding-top: 0;
     padding-bottom: clamp(1.5rem, 2vw, 3rem);
+}
+
+body.is-bending-view:not(.is-generator-view) .app-main {
+    padding-bottom: 0;
 }
 
 @media (max-width: 1600px) {


### PR DESCRIPTION
## Summary
- add an explicit `is-generator-view` state on the body so navigation changes collapse the generator layout when leaving the generator
- hide the generator container and relax the app wrapper height when another view is active to eliminate the large gap above non-generator content
- ensure bending views also ignore the generator padding so their cards sit directly under the navbar

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68d50d1b666c832da21e9e1469334fcf