### PR TITLE
Separate ABS upload trigger from table interactions

### DIFF
--- a/bf2d-configurator.js
+++ b/bf2d-configurator.js
@@ -706,14 +706,18 @@
 
         const dropZone = document.getElementById('bf2dDropZone');
         const importInput = document.getElementById('bf2dImportFileInput');
-        if (dropZone && importInput) {
-            dropZone.addEventListener('click', () => importInput.click());
+        if (dropZone) {
             dropZone.addEventListener('dragover', handleDragOver);
             dropZone.addEventListener('dragleave', handleDragLeave);
             dropZone.addEventListener('drop', handleDrop);
         }
         if (importInput) {
             importInput.addEventListener('change', handleFileInputChange);
+        }
+
+        const openImportButton = document.getElementById('bf2dOpenImportButton');
+        if (openImportButton && importInput) {
+            openImportButton.addEventListener('click', () => importInput.click());
         }
 
         const exportButton = document.getElementById('bf2dExportSelectionButton');
@@ -2803,7 +2807,7 @@
             content.style.display = 'none';
             clearButton.style.display = 'none';
             if (dropZone) {
-                dropZone.style.cursor = 'pointer';
+                dropZone.style.cursor = 'default';
             }
         } else if (state === 'data') {
             instructions.style.display = 'none';

--- a/index.html
+++ b/index.html
@@ -651,6 +651,12 @@
                             <div class="card-header">
                                 <h2 class="card-title" data-i18n="ABS-Import">ABS-Import</h2>
                                 <div class="button-group" style="justify-content: flex-end;">
+                                    <button type="button" id="bf2dOpenImportButton" class="btn-primary">
+                                        <svg viewBox="0 0 24 24" aria-hidden="true">
+                                            <path d="M19.35 10.04C18.67 6.59 15.64 4 12 4c-2.89 0-5.4 1.64-6.65 4.04C2.34 8.36 0 10.91 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96zM17 13l-5 5-5-5h3V9h4v4h3z"/>
+                                        </svg>
+                                        <span data-i18n="ABS-Datei importieren">ABS-Datei importieren</span>
+                                    </button>
                                     <button type="button" id="bf2dClearImportButton" class="btn-secondary" style="display: none;">
                                         <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg>
                                         <span data-i18n="Import löschen">Import löschen</span>
@@ -667,7 +673,7 @@
                                         <svg class="bf2d-drop-zone-icon" viewBox="0 0 24 24" aria-hidden="true">
                                             <path d="M19.35 10.04C18.67 6.59 15.64 4 12 4 9.11 4 6.6 5.64 5.35 8.04 2.34 8.36 0 10.91 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96zM17 13l-5 5-5-5h3V9h4v4h3z"/>
                                         </svg>
-                                        <p data-i18n="ABS-Datei hierher ziehen oder klicken, um eine auszuwählen.">ABS-Datei hierher ziehen oder<br>klicken, um eine auszuwählen.</p>
+                                        <p data-i18n="ABS-Datei hierher ziehen oder den Button verwenden.">ABS-Datei hierher ziehen oder<br>den Button oben verwenden.</p>
                                         <span class="bf2d-drop-zone-note" data-i18n="Dateityp: .abs">Dateityp: .abs</span>
                                     </div>
                                     <div id="bf2dImportContent" class="bf2d-import-content" style="display: none;">

--- a/lang/cz.json
+++ b/lang/cz.json
@@ -292,6 +292,7 @@
   "Keine gültige Vorschau verfügbar.": "Platný náhled není k dispozici.",
   "ABS-Import": "Import ABS",
   "ABS-Datei importieren": "Importovat soubor ABS",
+  "ABS-Datei hierher ziehen oder den Button verwenden.": "Přetáhněte soubor ABS sem nebo použijte tlačítko výše.",
   "Auswahl exportieren": "Exportovat výběr",
   "Keine Positionen importiert.": "Nebyla importována žádná pozice.",
   "⌀ (mm)": "⌀ (mm)",

--- a/lang/de.json
+++ b/lang/de.json
@@ -292,6 +292,7 @@
   "Keine gültige Vorschau verfügbar.": "Keine gültige Vorschau verfügbar.",
   "ABS-Import": "ABS-Import",
   "ABS-Datei importieren": "ABS-Datei importieren",
+  "ABS-Datei hierher ziehen oder den Button verwenden.": "ABS-Datei hierher ziehen oder den Button verwenden.",
   "Auswahl exportieren": "Auswahl exportieren",
   "Keine Positionen importiert.": "Keine Positionen importiert.",
   "⌀ (mm)": "⌀ (mm)",

--- a/lang/en.json
+++ b/lang/en.json
@@ -292,6 +292,7 @@
   "Keine gültige Vorschau verfügbar.": "No valid preview available.",
   "ABS-Import": "ABS import",
   "ABS-Datei importieren": "Import ABS file",
+  "ABS-Datei hierher ziehen oder den Button verwenden.": "Drag ABS file here or use the button above.",
   "Auswahl exportieren": "Export selection",
   "Keine Positionen importiert.": "No positions imported.",
   "⌀ (mm)": "⌀ (mm)",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -292,6 +292,7 @@
   "Keine gültige Vorschau verfügbar.": "Podgląd jest niedostępny.",
   "ABS-Import": "Import ABS",
   "ABS-Datei importieren": "Importuj plik ABS",
+  "ABS-Datei hierher ziehen oder den Button verwenden.": "Przeciągnij plik ABS tutaj lub użyj przycisku powyżej.",
   "Auswahl exportieren": "Eksportuj zaznaczenie",
   "Keine Positionen importiert.": "Nie zaimportowano pozycji.",
   "⌀ (mm)": "⌀ (mm)",


### PR DESCRIPTION
## Summary
- add a dedicated ABS import button so the dataset table remains interactive after loading
- update configurator logic to bind the upload input to the new button while retaining drag-and-drop support
- refresh translations to reflect the new upload instructions

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d514f93c8c832da31b2a758d0a3459