### PR TITLE
Allow single segment BF2D shapes

### DIFF
--- a/bf2d-configurator.js
+++ b/bf2d-configurator.js
@@ -1196,7 +1196,7 @@
             const downButton = createActionButton('↓', 'Nach unten', () => moveSegment(index, 1));
             downButton.disabled = index === state.segments.length - 1;
             const removeButton = createActionButton('✕', 'Segment entfernen', () => removeSegment(segment.id));
-            removeButton.disabled = state.segments.length <= 2;
+            removeButton.disabled = state.segments.length <= 1;
             actionsCell.appendChild(upButton);
             actionsCell.appendChild(downButton);
             actionsCell.appendChild(removeButton);
@@ -1225,9 +1225,9 @@
 
     function removeSegment(id) {
         state.previewNoteOverride = null;
-        if (state.segments.length <= 2) {
+        if (state.segments.length <= 1) {
             if (typeof showFeedback === 'function') {
-                showFeedback('bf2dStatus', i18n.t('Mindestens zwei Segmente erforderlich.'), 'warning', 3000);
+                showFeedback('bf2dStatus', i18n.t('Mindestens ein Segment erforderlich.'), 'warning', 3000);
             }
             return;
         }
@@ -1257,8 +1257,8 @@
         applyRollDiameterToSegments();
 
         const segments = state.segments;
-        if (segments.length < 2) {
-            errors.push(i18n.t('Mindestens zwei Segmente erforderlich.'));
+        if (segments.length < 1) {
+            errors.push(i18n.t('Mindestens ein Segment erforderlich.'));
         }
 
         let straightLength = 0;

--- a/lang/cz.json
+++ b/lang/cz.json
@@ -278,7 +278,7 @@
   "Nach oben": "Nahoru",
   "Nach unten": "Dolů",
   "Segment entfernen": "Odstranit segment",
-  "Mindestens zwei Segmente erforderlich.": "Jsou potřeba alespoň dva segmenty.",
+  "Mindestens ein Segment erforderlich.": "Je potřeba alespoň jeden segment.",
   "Segment {index}: Länge muss größer als 0 sein.": "Segment {index}: délka musí být větší než 0.",
   "Segment {index}: Biegewinkel muss zwischen 0° und 180° liegen.": "Segment {index}: úhel ohybu musí být mezi 0° a 180°.",
   "Segment {index}: Radius muss größer als 0 sein, wenn ein Winkel definiert ist.": "Segment {index}: poloměr musí být větší než 0, pokud je zadán úhel.",

--- a/lang/de.json
+++ b/lang/de.json
@@ -278,7 +278,7 @@
   "Nach oben": "Nach oben",
   "Nach unten": "Nach unten",
   "Segment entfernen": "Segment entfernen",
-  "Mindestens zwei Segmente erforderlich.": "Mindestens zwei Segmente erforderlich.",
+  "Mindestens ein Segment erforderlich.": "Mindestens ein Segment erforderlich.",
   "Segment {index}: Länge muss größer als 0 sein.": "Segment {index}: Länge muss größer als 0 sein.",
   "Segment {index}: Biegewinkel muss zwischen 0° und 180° liegen.": "Segment {index}: Biegewinkel muss zwischen 0° und 180° liegen.",
   "Segment {index}: Radius muss größer als 0 sein, wenn ein Winkel definiert ist.": "Segment {index}: Radius muss größer als 0 sein, wenn ein Winkel definiert ist.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -278,7 +278,7 @@
   "Nach oben": "Move up",
   "Nach unten": "Move down",
   "Segment entfernen": "Remove segment",
-  "Mindestens zwei Segmente erforderlich.": "At least two segments are required.",
+  "Mindestens ein Segment erforderlich.": "At least one segment is required.",
   "Segment {index}: Länge muss größer als 0 sein.": "Segment {index}: length must be greater than 0.",
   "Segment {index}: Biegewinkel muss zwischen 0° und 180° liegen.": "Segment {index}: bending angle must be between 0° and 180°.",
   "Segment {index}: Radius muss größer als 0 sein, wenn ein Winkel definiert ist.": "Segment {index}: radius must be greater than 0 when an angle is defined.",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -278,7 +278,7 @@
   "Nach oben": "Do góry",
   "Nach unten": "W dół",
   "Segment entfernen": "Usuń segment",
-  "Mindestens zwei Segmente erforderlich.": "Wymagane są co najmniej dwa segmenty.",
+  "Mindestens ein Segment erforderlich.": "Wymagany jest co najmniej jeden segment.",
   "Segment {index}: Länge muss größer als 0 sein.": "Segment {index}: długość musi być większa od 0.",
   "Segment {index}: Biegewinkel muss zwischen 0° und 180° liegen.": "Segment {index}: kąt gięcia musi mieścić się w przedziale 0°–180°.",
   "Segment {index}: Radius muss größer als 0 sein, wenn ein Winkel definiert ist.": "Segment {index}: promień musi być większy od 0, jeśli zdefiniowano kąt.",


### PR DESCRIPTION
## Summary
- allow BF2D shapes to consist of a single straight segment by relaxing the minimum segment checks
- update internationalized feedback strings to reflect the new minimum segment requirement

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d517856384832d84fc820411d73c2c