### PR TITLE
Fix resource form submission and expand resources view width

### DIFF
--- a/production.js
+++ b/production.js
@@ -2340,6 +2340,7 @@ function handleResourceFormSubmit(event) {
     const maxDiameterInput = form.querySelector('#resourceMaxDiameter');
     const minLegInput = form.querySelector('#resourceMinLegLength');
     const maxLegInput = form.querySelector('#resourceMaxLegLength');
+    const rollDiametersInput = form.querySelector('#resourceRollDiameters');
 
     const minDiameter = parseResourceNumber(minDiameterInput ? minDiameterInput.value : null);
     const maxDiameter = parseResourceNumber(maxDiameterInput ? maxDiameterInput.value : null);
@@ -2370,7 +2371,7 @@ function handleResourceFormSubmit(event) {
 
     const description = descriptionInput ? descriptionInput.value.trim() : '';
     const supportedTypes = Array.from(form.querySelectorAll('input[name="resourceTypes"]:checked')).map(input => input.value);
-    const availableRollDiameters = normalizeRollDiameterValues(rollDiametersInput ? rollDiametersInput.value : []);
+    const availableRollDiameters = normalizeRollDiameterValues(rollDiametersInput ? rollDiametersInput.value : '');
 
     if (editingResourceId) {
         const index = resources.findIndex(item => item.id === editingResourceId);

--- a/styles.css
+++ b/styles.css
@@ -901,6 +901,10 @@ body:not(.is-generator-view) .app-main {
     box-sizing: border-box;
 }
 
+#resourcesView.app-container {
+    max-width: none;
+}
+
 .app-footer {
     margin-top: auto;
     padding: 0 0 2rem;


### PR DESCRIPTION
## Summary
- ensure the resource form handler reads the roll diameter input before normalizing values to avoid runtime errors when saving
- allow the resources view container to span the full available width instead of being constrained to the global max width

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d51e0c1724832da480df270f6c4c61