### PR TITLE
Refine BF2D configurator form layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -524,38 +524,48 @@
                                 <h2 class="card-title" data-i18n="BF2D Konfigurator">BF2D Konfigurator</h2>
                             </div>
                             <div class="bf2d-form-grid">
-                                <div class="form-group">
-                                    <label for="bf2dProject" data-i18n="Projekt">Projekt</label>
-                                    <input type="text" id="bf2dProject" value="Projekt A">
-                                </div>
-                                <div class="form-group">
-                                    <label for="bf2dOrder" data-i18n="Auftrag">Auftrag</label>
-                                    <input type="text" id="bf2dOrder" value="A-001">
-                                </div>
-                                <div class="form-group">
-                                    <label for="bf2dPosition" data-i18n="Pos.-Nr.">Pos.-Nr.</label>
-                                    <input type="text" id="bf2dPosition" value="1">
-                                </div>
-                                <div class="form-group">
-                                    <label for="bf2dDiameter" data-i18n="Durchmesser (mm)">Durchmesser (mm)</label>
-                                    <input type="number" id="bf2dDiameter" value="12" min="1" step="0.1">
-                                </div>
-                                <div class="form-group">
-                                    <label for="bf2dRollDiameter" data-i18n="Biegerollendurchmesser (mm)">Biegerollendurchmesser (mm)</label>
-                                    <select id="bf2dRollDiameter" data-masterdata-source="rollDiameters" data-masterdata-placeholder-key="Biegerollendurchmesser auswählen…" data-masterdata-default="48"></select>
-                                </div>
-                                <div class="form-group">
-                                    <label for="bf2dQuantity" data-i18n="Stückzahl">Stückzahl</label>
-                                    <input type="number" id="bf2dQuantity" value="1" min="1" step="1">
-                                </div>
-                                <div class="form-group">
-                                    <label for="bf2dSteelGrade" data-i18n="Stahlsorte">Stahlsorte</label>
-                                    <select id="bf2dSteelGrade" data-masterdata-source="steelGrades" data-masterdata-placeholder-key="Stahlsorte auswählen…" data-masterdata-default="B500B"></select>
-                                </div>
-                                <div class="form-group">
-                                    <label for="bf2dRemark" data-i18n="Bemerkung">Bemerkung</label>
-                                    <input type="text" id="bf2dRemark">
-                                </div>
+                                <section class="bf2d-form-section">
+                                    <h3 class="bf2d-form-section-title" data-i18n="Allgemeine Angaben">Allgemeine Angaben</h3>
+                                    <div class="bf2d-form-section-body">
+                                        <div class="form-group">
+                                            <label for="bf2dProject" data-i18n="Projekt">Projekt</label>
+                                            <input type="text" id="bf2dProject" value="Projekt A">
+                                        </div>
+                                        <div class="form-group">
+                                            <label for="bf2dOrder" data-i18n="Auftrag">Auftrag</label>
+                                            <input type="text" id="bf2dOrder" value="A-001">
+                                        </div>
+                                        <div class="form-group">
+                                            <label for="bf2dPosition" data-i18n="Pos.-Nr.">Pos.-Nr.</label>
+                                            <input type="text" id="bf2dPosition" value="1">
+                                        </div>
+                                        <div class="form-group">
+                                            <label for="bf2dRemark" data-i18n="Bemerkung">Bemerkung</label>
+                                            <input type="text" id="bf2dRemark">
+                                        </div>
+                                    </div>
+                                </section>
+                                <section class="bf2d-form-section">
+                                    <h3 class="bf2d-form-section-title" data-i18n="Produktionsparameter">Produktionsparameter</h3>
+                                    <div class="bf2d-form-section-body">
+                                        <div class="form-group">
+                                            <label for="bf2dDiameter" data-i18n="Durchmesser (mm)">Durchmesser (mm)</label>
+                                            <input type="number" id="bf2dDiameter" value="12" min="1" step="0.1">
+                                        </div>
+                                        <div class="form-group">
+                                            <label for="bf2dRollDiameter" data-i18n="Biegerollendurchmesser (mm)">Biegerollendurchmesser (mm)</label>
+                                            <select id="bf2dRollDiameter" data-masterdata-source="rollDiameters" data-masterdata-placeholder-key="Biegerollendurchmesser auswählen…" data-masterdata-default="48"></select>
+                                        </div>
+                                        <div class="form-group">
+                                            <label for="bf2dQuantity" data-i18n="Stückzahl">Stückzahl</label>
+                                            <input type="number" id="bf2dQuantity" value="1" min="1" step="1">
+                                        </div>
+                                        <div class="form-group">
+                                            <label for="bf2dSteelGrade" data-i18n="Stahlsorte">Stahlsorte</label>
+                                            <select id="bf2dSteelGrade" data-masterdata-source="steelGrades" data-masterdata-placeholder-key="Stahlsorte auswählen…" data-masterdata-default="B500B"></select>
+                                        </div>
+                                    </div>
+                                </section>
                             </div>
                             <div class="bf2d-storage-controls">
                                 <div class="form-group">

--- a/lang/cz.json
+++ b/lang/cz.json
@@ -38,6 +38,8 @@
   "Summe Bügel": "Celkový počet třmínků",
   "Füge Zonen hinzu, um zu starten.": "Přidejte zóny pro zahájení.",
   "Visuelle Vorschau Korb": "Vizuální náhled koše",
+  "Allgemeine Angaben": "Základní údaje",
+  "Produktionsparameter": "Parametry výroby",
   "Interaktive Vorschau und Kontrolle": "Interaktivní náhled a kontrola",
   "Ansicht": "Zobrazení",
   "Darstellung": "Vizualizace",

--- a/lang/de.json
+++ b/lang/de.json
@@ -38,6 +38,8 @@
   "Summe Bügel": "Summe Bügel",
   "Füge Zonen hinzu, um zu starten.": "Füge Zonen hinzu, um zu starten.",
   "Visuelle Vorschau Korb": "Visuelle Vorschau Korb",
+  "Allgemeine Angaben": "Allgemeine Angaben",
+  "Produktionsparameter": "Produktionsparameter",
   "Interaktive Vorschau und Kontrolle": "Interaktive Vorschau und Kontrolle",
   "Ansicht": "Ansicht",
   "Darstellung": "Darstellung",

--- a/lang/en.json
+++ b/lang/en.json
@@ -38,6 +38,8 @@
   "Summe Bügel": "Total stirrups",
   "Füge Zonen hinzu, um zu starten.": "Add zones to get started.",
   "Visuelle Vorschau Korb": "Visual Cage Preview",
+  "Allgemeine Angaben": "General information",
+  "Produktionsparameter": "Production parameters",
   "Interaktive Vorschau und Kontrolle": "Interactive preview and control",
   "Ansicht": "View",
   "Darstellung": "Display",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -38,6 +38,8 @@
   "Summe Bügel": "Łączna liczba strzemion",
   "Füge Zonen hinzu, um zu starten.": "Dodaj strefy, aby rozpocząć.",
   "Visuelle Vorschau Korb": "Wizualny podgląd kosza",
+  "Allgemeine Angaben": "Dane ogólne",
+  "Produktionsparameter": "Parametry produkcji",
   "Interaktive Vorschau und Kontrolle": "Interaktywny podgląd i kontrola",
   "Ansicht": "Widok",
   "Darstellung": "Wizualizacja",

--- a/styles.css
+++ b/styles.css
@@ -3285,6 +3285,45 @@ body.is-bending-view:not(.is-generator-view) .app-main {
     }
 }
 
+#bf2dView .bf2d-form-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+#bf2dView .bf2d-form-section {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1.25rem;
+    border-radius: var(--border-radius);
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    background: rgba(148, 163, 184, 0.08);
+}
+
+#bf2dView .bf2d-form-section-title {
+    margin: 0;
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: var(--heading-color);
+}
+
+#bf2dView .bf2d-form-section-body {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: 1fr;
+}
+
+body[data-density="compact"] #bf2dView .bf2d-form-section {
+    padding: 1rem;
+    gap: 0.75rem;
+}
+
+body[data-theme="dark"] #bf2dView .bf2d-form-section {
+    background: rgba(15, 23, 42, 0.65);
+    border-color: rgba(148, 163, 184, 0.28);
+}
+
 .bf2d-form-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));


### PR DESCRIPTION
## Summary
- restructure the BF2D configurator form into clearly labeled sections so inputs appear stacked vertically
- add styling rules that emphasize the new section layout while preserving compact and dark themes
- extend all language files with translations for the new section headings

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d524efb514832dbc7ab46a15ceddfe