### PR TITLE
Enable editing saved bending forms from overview

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -4519,6 +4519,21 @@ body[data-theme="dark"] .saved-shapes-count {
     flex-direction: column;
     gap: 0.75rem;
     box-shadow: var(--shadow-sm);
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+    outline: none;
+}
+
+.saved-shape-card:hover,
+.saved-shape-card:focus-visible {
+    border-color: rgba(var(--primary-color-rgb), 0.35);
+    box-shadow: var(--shadow-md);
+}
+
+.saved-shape-card:focus-visible {
+    transform: translateY(-1px);
+    outline: 2px solid rgba(var(--primary-color-rgb), 0.6);
+    outline-offset: 3px;
 }
 
 .saved-shape-card-header {


### PR DESCRIPTION
## Summary
- make saved shape cards interactive so a click opens the proper configurator and loads the stored data
- add loader helpers to the 2D, 3D, and mat configurators so shapes can be restored programmatically
- tweak saved shape card styling for focus and hover feedback when cards are used as buttons

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5350fd0f8832d8c42b5566d68043f