### PR TITLE
Reorder BF3D dataset card and widen configurator column

### DIFF
--- a/index.html
+++ b/index.html
@@ -893,9 +893,7 @@
                     </div>
                 </div>
             </div>
-        </div>
-        <div class="bf3d-column">
-            <div class="card">
+            <div class="card dataset-card">
                 <div class="card-header">
                     <h2 class="card-title" data-i18n="BVBS-ABS Datensatz">BVBS-ABS Datensatz</h2>
                 </div>

--- a/styles.css
+++ b/styles.css
@@ -3168,7 +3168,7 @@ select.status-select.done {
 
 #bf3dView .bf3d-layout {
     display: grid;
-    grid-template-columns: minmax(320px, 380px) minmax(360px, 1fr) minmax(260px, 320px);
+    grid-template-columns: minmax(360px, 460px) minmax(420px, 1fr);
     gap: clamp(1.5rem, 2.5vw, 2.5rem);
     align-items: start;
     width: 100%;
@@ -3185,7 +3185,7 @@ select.status-select.done {
     margin: 0;
 }
 
-#bf3dView .bf3d-column--preview .card {
+#bf3dView .bf3d-column--preview .preview-card {
     height: 100%;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary
- place the BVBS-ABS dataset card directly below the preview card on the BF3D page
- widen the first column in the BF3D layout and keep the preview card flex behavior scoped to it

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d53ba62648832daac43ece412915d2