### PR TITLE
Reorder BFMA layout cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -1062,16 +1062,17 @@
             </div>
         </div>
 
-        <div class="preview-column">
-             <div class="card bf2d-import-card bfma-import-card">
-                <div class="card-header">
-                    <h2 class="card-title" data-i18n="ABS-Import/Export">ABS-Import/Export</h2>
-                </div>
-                <div id="bfmaDropZone" class="bf2d-drop-zone">
-                    <p data-i18n="ABS-Datei hierher ziehen...">ABS-Datei hierher ziehen...</p>
-                </div>
-                <input type="file" id="bfmaImportFileInput" accept=".abs,text/plain" style="display:none">
+        <div class="card bf2d-import-card bfma-import-card">
+            <div class="card-header">
+                <h2 class="card-title" data-i18n="ABS-Import/Export">ABS-Import/Export</h2>
             </div>
+            <div id="bfmaDropZone" class="bf2d-drop-zone">
+                <p data-i18n="ABS-Datei hierher ziehen...">ABS-Datei hierher ziehen...</p>
+            </div>
+            <input type="file" id="bfmaImportFileInput" accept=".abs,text/plain" style="display:none">
+        </div>
+
+        <div class="preview-column">
             <div class="card preview-card bfma-preview-card">
                 <div class="card-header">
                     <h2 class="card-title" data-i18n="Vorschau">Vorschau</h2>

--- a/styles.css
+++ b/styles.css
@@ -3903,7 +3903,7 @@ body[data-theme="dark"] .bf2d-machine-list-item {
 /* BFMA Konfigurator */
 .bfma-layout {
     display: grid;
-    grid-template-columns: minmax(360px, 1.2fr) minmax(320px, 1fr) minmax(320px, 1fr);
+    grid-template-columns: minmax(360px, 1.2fr) minmax(320px, 1fr);
     gap: clamp(1.5rem, 2.5vw, 2.5rem);
     align-items: start;
     grid-auto-flow: row;
@@ -3932,14 +3932,14 @@ body[data-theme="dark"] .bf2d-machine-list-item {
 }
 
 #bfmaView .bfma-import-card {
-    grid-column: 2;
+    grid-column: 1;
     grid-row: 2;
     align-self: start;
 }
 
 #bfmaView .bfma-output-card {
-    grid-column: 3;
-    grid-row: 1 / span 2;
+    grid-column: 2;
+    grid-row: 2;
     align-self: stretch;
 }
 


### PR DESCRIPTION
## Summary
- move the ABS import/export card so it sits beneath the BFMA configurator
- keep the BVBS-ABS dataset card directly under the preview and adjust the grid layout accordingly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d53d1870a4832dbe9e455939e26f57