### PR TITLE
Add type fields to BF configurators

### DIFF
--- a/bf2d-configurator.js
+++ b/bf2d-configurator.js
@@ -4,6 +4,7 @@
         project: '',
         order: '',
         position: '',
+        type: 'BWS',
         diameter: 12,
         rollDiameter: 48,
         quantity: 1,
@@ -515,6 +516,7 @@
             { id: 'bf2dProject', key: 'project', parser: value => (value || '').trim() },
             { id: 'bf2dOrder', key: 'order', parser: value => (value || '').trim() },
             { id: 'bf2dPosition', key: 'position', parser: value => (value || '').trim() },
+            { id: 'bf2dType', key: 'type', parser: value => (value || '').trim() },
             {
                 id: 'bf2dDiameter',
                 key: 'diameter',
@@ -2187,6 +2189,7 @@
         const project = sanitizeText(state.meta.project);
         const order = sanitizeText(state.meta.order);
         const position = sanitizeText(state.meta.position);
+        const type = sanitizeText(state.meta.type) || 'BWS';
         const steelGrade = sanitizeText(state.meta.steelGrade);
         const remark = sanitizeText(state.meta.remark);
         const diameter = Number(state.meta.diameter) || 0;
@@ -2197,7 +2200,7 @@
         lines.push('BVBS;3.1;ABS');
         lines.push('ST;FORM;BF2D');
         lines.push(`ID;${project};${order};${position};${remark}`);
-        lines.push(`PR;DIAMETER;${formatNumberForDataset(diameter)};STEEL;${steelGrade};QUANTITY;${quantity};S;${formatNumberForDataset(Math.max(rollDiameter, 0))}`);
+        lines.push(`PR;TYPE;${type};DIAMETER;${formatNumberForDataset(diameter)};STEEL;${steelGrade};QUANTITY;${quantity};S;${formatNumberForDataset(Math.max(rollDiameter, 0))}`);
         lines.push(`RE;STRAIGHT;${formatNumberForDataset(summary.straightLength)};ARC;${formatNumberForDataset(summary.arcLength)};TOTAL;${formatNumberForDataset(summary.totalLength)}`);
 
         state.segments.forEach((segment, index) => {
@@ -2599,6 +2602,7 @@
                 project: getFirstFieldValue(headerBlock, 'j') || '',
                 order: getFirstFieldValue(headerBlock, 'i') || '',
                 position: getFirstFieldValue(headerBlock, 'p') || '',
+                type: getFirstFieldValue(headerBlock, 't') || '',
                 diameter,
                 diameterRaw: typeof diameterRaw === 'string' ? diameterRaw : '',
                 totalLength: Number.isFinite(totalLength) ? totalLength : NaN,
@@ -2613,6 +2617,7 @@
                 project: '',
                 order: '',
                 position: '',
+                type: '',
                 diameter: NaN,
                 diameterRaw: '',
                 totalLength: NaN,
@@ -3065,6 +3070,7 @@
         meta.project = header.project || META_DEFAULTS.project;
         meta.order = header.order || META_DEFAULTS.order;
         meta.position = header.position || META_DEFAULTS.position;
+        meta.type = header.type || META_DEFAULTS.type;
         meta.steelGrade = header.steelGrade || META_DEFAULTS.steelGrade;
         meta.remark = header.remark || META_DEFAULTS.remark;
         const quantity = Number.isFinite(header.quantity) && header.quantity > 0 ? Math.round(header.quantity) : META_DEFAULTS.quantity;

--- a/bf3d-configurator.js
+++ b/bf3d-configurator.js
@@ -5,7 +5,7 @@
     }
 
     const state = {
-        header: { p: '1', n: 1, d: 10, g: 'B500B', s: 40 },
+        header: { p: '1', t: 'BWS', n: 1, d: 10, g: 'B500B', s: 40 },
         points: [],
         selectedPointId: null,
         history: [],
@@ -515,7 +515,8 @@
             return "Fehler: Mindestens 2 Punkte erforderlich.";
         }
         const h = state.header;
-        const headerString = `BF3D@H@P${h.p}@N${h.n}@D${h.d}@G${h.g}@S${h.s}@`;
+        const sanitizeType = value => (value ?? '').toString().replace(/@/g, '').trim();
+        const headerString = `BF3D@H@P${h.p}@N${h.n}@D${h.d}@G${h.g}@S${h.s}@T${sanitizeType(h.t)}@`;
 
         let geometryString = 'G';
         let lastPoint = { x: 0, y: 0, z: 0 };
@@ -550,8 +551,11 @@
 
 
     function updateAll() {
+        state.header.t = (state.header.t ?? '').toString().trim() || 'BWS';
+
         const headerInputs = [
             { key: 'p', id: 'bf3dPosition', type: 'string' },
+            { key: 't', id: 'bf3dType', type: 'string' },
             { key: 'n', id: 'bf3dQuantity', type: 'number' },
             { key: 'd', id: 'bf3dDiameter', type: 'number' },
             { key: 'g', id: 'bf3dSteelGrade', type: 'string' },
@@ -861,7 +865,7 @@
         });
 
         // Header inputs
-        ['p:bf3dPosition', 'n:bf3dQuantity', 'd:bf3dDiameter', 'g:bf3dSteelGrade', 's:bf3dBendingRoller'].forEach(mapping => {
+        ['p:bf3dPosition', 't:bf3dType', 'n:bf3dQuantity', 'd:bf3dDiameter', 'g:bf3dSteelGrade', 's:bf3dBendingRoller'].forEach(mapping => {
             const [key, id] = mapping.split(':');
             const el = document.getElementById(id);
             if (el) {

--- a/bfma-configurator.js
+++ b/bfma-configurator.js
@@ -2,7 +2,7 @@
 (function () {
     const STORAGE_KEY = 'bfmaSavedMeshes';
     const state = {
-        header: { p: '1', l: 5000, b: 2000, n: 1, e: 0, g: 'B500A', m: 'Q257', s: 0, v: '', a: '' },
+        header: { p: '1', l: 5000, b: 2000, n: 1, t: 'BWM', e: 0, g: 'B500A', m: 'Q257', s: 0, v: '', a: '' },
         yBars: [], xBars: [], eBars: [],
         bending: { active: false, direction: 'Gy', sequence: [] },
         preview: normalizePreviewSettings({ showDimensions: true, showPitch: false }),
@@ -785,6 +785,7 @@
 
     function buildAbsDataset() {
         const header = state.header;
+        header.t = (header.t ?? '').toString().trim() || 'BWM';
         const headerParts = [
             `P${header.p ?? ''}`,
             `L${formatDatasetNumber(parseNumber(header.l), 0)}`,
@@ -793,7 +794,8 @@
             `E${formatDatasetNumber(parseNumber(header.e), 2)}`,
             `G${header.g ?? ''}`,
             `M${header.m ?? ''}`,
-            `S${formatDatasetNumber(parseNumber(header.s), 0)}`
+            `S${formatDatasetNumber(parseNumber(header.s), 0)}`,
+            `T${header.t.replace(/@/g, '')}`
         ];
         const lines = ['BFMA@', `H@${headerParts.join('@')}@`];
         state.yBars.forEach((bar, index) => {
@@ -997,6 +999,7 @@
             { id: 'bfmaLength', key: 'l', parser: parseNumber },
             { id: 'bfmaWidth', key: 'b', parser: parseNumber },
             { id: 'bfmaQuantity', key: 'n', parser: parseNumber },
+            { id: 'bfmaType', key: 't', parser: value => value.trim() },
             { id: 'bfmaWeight', key: 'e', parser: parseNumber },
             { id: 'bfmaSteelGrade', key: 'g', parser: value => value.trim() },
             { id: 'bfmaMeshType', key: 'm', parser: value => value.trim() },
@@ -1008,14 +1011,17 @@
             const value = item.parser(el.value ?? '');
             state.header[item.key] = typeof value === 'string' ? value : parseNumber(value);
         });
+        state.header.t = (state.header.t ?? '').toString().trim() || 'BWM';
     }
 
     function applyHeaderStateToInputs() {
+        state.header.t = (state.header.t ?? '').toString().trim() || 'BWM';
         const mapping = [
             { id: 'bfmaPos', key: 'p' },
             { id: 'bfmaLength', key: 'l' },
             { id: 'bfmaWidth', key: 'b' },
             { id: 'bfmaQuantity', key: 'n' },
+            { id: 'bfmaType', key: 't' },
             { id: 'bfmaWeight', key: 'e' },
             { id: 'bfmaSteelGrade', key: 'g' },
             { id: 'bfmaMeshType', key: 'm' },
@@ -1065,6 +1071,7 @@
             { id: 'bfmaLength', key: 'l', handler: parseNumber },
             { id: 'bfmaWidth', key: 'b', handler: parseNumber },
             { id: 'bfmaQuantity', key: 'n', handler: parseNumber },
+            { id: 'bfmaType', key: 't', handler: value => value.trim() },
             { id: 'bfmaSteelGrade', key: 'g', handler: value => value.trim() },
             { id: 'bfmaMeshType', key: 'm', handler: value => value.trim() },
             { id: 'bfmaBendingRoll', key: 's', handler: parseNumber }

--- a/index.html
+++ b/index.html
@@ -540,6 +540,10 @@
                                             <input type="text" id="bf2dPosition" value="1">
                                         </div>
                                         <div class="form-group">
+                                            <label for="bf2dType" data-i18n="Typ">Typ</label>
+                                            <input type="text" id="bf2dType" value="BWS">
+                                        </div>
+                                        <div class="form-group">
                                             <label for="bf2dRemark" data-i18n="Bemerkung">Bemerkung</label>
                                             <input type="text" id="bf2dRemark">
                                         </div>
@@ -789,6 +793,10 @@
                         <input type="text" id="bf3dPosition" value="1">
                     </div>
                     <div class="form-group">
+                        <label for="bf3dType" data-i18n="Typ">Typ</label>
+                        <input type="text" id="bf3dType" value="BWS">
+                    </div>
+                    <div class="form-group">
                         <label for="bf3dQuantity" data-i18n="Anzahl (n)">Anzahl (n)</label>
                         <input type="number" id="bf3dQuantity" value="1" min="1">
                     </div>
@@ -935,6 +943,10 @@
                 <div class="form-group">
                     <label for="bfmaQuantity" data-i18n="Anzahl (n)">Anzahl (n)</label>
                     <input type="number" id="bfmaQuantity" value="1">
+                </div>
+                <div class="form-group">
+                    <label for="bfmaType" data-i18n="Typ">Typ</label>
+                    <input type="text" id="bfmaType" value="BWM">
                 </div>
                 <div class="form-group">
                     <label for="bfmaWeight" data-i18n="Gewicht (e) kg">Gewicht (e) kg</label>


### PR DESCRIPTION
## Summary
- add a "Typ" input to the BF2D, BF3D and BFMA general sections with the required default values
- persist the new type metadata in the respective configurator state, dataset generation and import flows

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5402c433c832d934050217d5c9c7d