### PR TITLE
Make BVBS table header sticky and relocate filter

### DIFF
--- a/index.html
+++ b/index.html
@@ -1489,12 +1489,6 @@
                                 </div>
                             </div>
                             <div class="bvbs-toolbar-body">
-                                <div class="bvbs-toolbar-row">
-                                    <div class="bvbs-filter-group">
-                                        <label for="bvbsListFilterInput" data-i18n="Filter">Filter</label>
-                                        <input type="search" id="bvbsListFilterInput" data-i18n-placeholder="Filter" placeholder="Filter" autocomplete="off">
-                                    </div>
-                                </div>
                                 <div id="bvbsListDropZone" class="bf2d-drop-zone">
                                     <div class="bf2d-drop-zone-content">
                                         <div class="bf2d-drop-zone-instructions">
@@ -1512,6 +1506,10 @@
                         <div class="card bvbs-table-card">
                             <div class="card-header">
                                 <h2 class="card-title" data-i18n="BVBS-Inhalt">BVBS-Inhalt</h2>
+                                <div class="bvbs-filter-group">
+                                    <label for="bvbsListFilterInput" data-i18n="Filter">Filter</label>
+                                    <input type="search" id="bvbsListFilterInput" data-i18n-placeholder="Filter" placeholder="Filter" autocomplete="off">
+                                </div>
                             </div>
                             <div class="production-table-wrapper">
                                 <table id="bvbsListTable" class="full-width-table">

--- a/styles.css
+++ b/styles.css
@@ -3016,7 +3016,18 @@ body[data-theme="dark"] .stirrup-form-preview__canvas {
     align-self: stretch;
 }
 
+#bvbsListView .bvbs-table-card .card-header {
+    margin-bottom: 0;
+    flex-wrap: wrap;
+    align-items: flex-end;
+}
+
+#bvbsListView .bvbs-table-card .card-header .bvbs-filter-group {
+    margin-left: auto;
+}
+
 #bvbsListView .production-table-wrapper {
+    position: relative;
     overflow: auto;
     max-height: calc(100vh - 280px);
     border: 1px solid var(--border-color);
@@ -3024,8 +3035,11 @@ body[data-theme="dark"] .stirrup-form-preview__canvas {
     background-color: var(--card-bg-color);
 }
 
-#bvbsListView .bvbs-table-card .card-header {
-    margin-bottom: 0;
+#bvbsListView .production-table-wrapper thead th {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    background-color: var(--secondary-color);
 }
 
 #bvbsListView #bvbsListImportStatus {


### PR DESCRIPTION
## Summary
- move the BVBS table filter into the BVBS content card so it lives with the data it controls
- enable a sticky table header inside the scrollable BVBS list to keep column titles visible while scrolling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5926bae2c832d8d9409dd58101bed