### PR TITLE
Move optional PREFORM data into input card

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,6 +164,41 @@
                                         <select id="stahlgute" data-masterdata-source="steelGrades" data-masterdata-placeholder-key="Stahlsorte auswählen…" data-masterdata-default="B500B" oninput="triggerPreviewUpdateDebounced()"></select>
                                     </div>
                                 </div>
+                                <h3 class="section-title collapsible-header" data-i18n="Optionale (PREFORM 4.0) Daten">Optionale (PREFORM 4.0) Daten</h3>
+                                <div class="collapsible-content section-content-bg">
+                                    <div class="form-group">
+                                        <label for="buegelname1" data-i18n="Bügelname (s) - Zone 1">Bügelname (s) - Zone 1</label>
+                                        <div class="input-with-dropdown">
+                                            <input type="text" id="buegelname1" value="Forma1" maxlength="30" oninput="triggerPreviewUpdateDebounced()">
+                                            <button type="button" class="saved-form-button" id="buegelname1PickerButton" data-target-input="buegelname1" data-zone-label="Zone 1" aria-haspopup="dialog">
+                                                <span class="saved-form-button-icon" aria-hidden="true">
+                                                    <svg viewBox="0 0 24 24" focusable="false">
+                                                        <path d="M4 5h16v2H4V5zm3 6h10v2H7v-2zm-3 6h16v2H4v-2z" />
+                                                    </svg>
+                                                </span>
+                                                <span class="saved-form-button-text" data-default-text="Gespeicherte Biegeform wählen" data-i18n="Gespeicherte Biegeform wählen">Gespeicherte Biegeform wählen</span>
+                                            </button>
+                                        </div>
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="buegelname2" data-i18n="Bügelname (s) - Zone 2">Bügelname (s) - Zone 2</label>
+                                        <div class="input-with-dropdown">
+                                            <input type="text" id="buegelname2" value="" maxlength="30" oninput="triggerPreviewUpdateDebounced()">
+                                            <button type="button" class="saved-form-button" id="buegelname2PickerButton" data-target-input="buegelname2" data-zone-label="Zone 2" aria-haspopup="dialog">
+                                                <span class="saved-form-button-icon" aria-hidden="true">
+                                                    <svg viewBox="0 0 24 24" focusable="false">
+                                                        <path d="M4 5h16v2H4V5zm3 6h10v2H7v-2zm-3 6h16v2H4v-2z" />
+                                                    </svg>
+                                                </span>
+                                                <span class="saved-form-button-text" data-default-text="Gespeicherte Biegeform wählen" data-i18n="Gespeicherte Biegeform wählen">Gespeicherte Biegeform wählen</span>
+                                            </button>
+                                        </div>
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="rezeptname" data-i18n="Rezeptname (r):">Rezeptname (r):</label>
+                                        <input type="text" id="rezeptname" value="RezeptABC" maxlength="30" oninput="triggerPreviewUpdateDebounced()">
+                                    </div>
+                                </div>
                                 <h3 class="section-title collapsible-header" data-i18n="PtGABBIE-Daten">PtGABBIE-Daten</h3>
                                 <div class="collapsible-content section-content-bg">
                                     <h4 style="font-size: .95rem; font-weight: 600; margin-bottom: .5rem; color: var(--heading-color);" data-i18n="Lagen-Templates">Lagen-Templates</h4>
@@ -311,45 +346,6 @@
                                 </svg>
                                 <span data-i18n="Vorschau als SVG">Vorschau als SVG</span>
                             </button>
-                        </div>
-                    </div>
-                    <div class="card optional-data-card">
-                        <div class="card-header" style="display: flex; justify-content: space-between; align-items: center;">
-                            <h3 class="section-title collapsible-header" data-i18n="Optionale (PREFORM 4.0) Daten">Optionale (PREFORM 4.0) Daten</h3>
-                        </div>
-                        <div class="collapsible-content section-content-bg">
-                            <div class="form-group">
-                                <label for="buegelname1" data-i18n="Bügelname (s) - Zone 1">Bügelname (s) - Zone 1</label>
-                                <div class="input-with-dropdown">
-                                    <input type="text" id="buegelname1" value="Forma1" maxlength="30" oninput="triggerPreviewUpdateDebounced()">
-                                    <button type="button" class="saved-form-button" id="buegelname1PickerButton" data-target-input="buegelname1" data-zone-label="Zone 1" aria-haspopup="dialog">
-                                        <span class="saved-form-button-icon" aria-hidden="true">
-                                            <svg viewBox="0 0 24 24" focusable="false">
-                                                <path d="M4 5h16v2H4V5zm3 6h10v2H7v-2zm-3 6h16v2H4v-2z" />
-                                            </svg>
-                                        </span>
-                                        <span class="saved-form-button-text" data-default-text="Gespeicherte Biegeform wählen" data-i18n="Gespeicherte Biegeform wählen">Gespeicherte Biegeform wählen</span>
-                                    </button>
-                                </div>
-                            </div>
-                            <div class="form-group">
-                                <label for="buegelname2" data-i18n="Bügelname (s) - Zone 2">Bügelname (s) - Zone 2</label>
-                                <div class="input-with-dropdown">
-                                    <input type="text" id="buegelname2" value="" maxlength="30" oninput="triggerPreviewUpdateDebounced()">
-                                    <button type="button" class="saved-form-button" id="buegelname2PickerButton" data-target-input="buegelname2" data-zone-label="Zone 2" aria-haspopup="dialog">
-                                        <span class="saved-form-button-icon" aria-hidden="true">
-                                            <svg viewBox="0 0 24 24" focusable="false">
-                                                <path d="M4 5h16v2H4V5zm3 6h10v2H7v-2zm-3 6h16v2H4v-2z" />
-                                            </svg>
-                                        </span>
-                                        <span class="saved-form-button-text" data-default-text="Gespeicherte Biegeform wählen" data-i18n="Gespeicherte Biegeform wählen">Gespeicherte Biegeform wählen</span>
-                                    </button>
-                                </div>
-                            </div>
-                            <div class="form-group">
-                                <label for="rezeptname" data-i18n="Rezeptname (r):">Rezeptname (r):</label>
-                                <input type="text" id="rezeptname" value="RezeptABC" maxlength="30" oninput="triggerPreviewUpdateDebounced()">
-                            </div>
                         </div>
                     </div>
                     <div class="card zone-summary-table-container">


### PR DESCRIPTION
## Summary
- place the optional PREFORM 4.0 data section inside the Eingabedaten card ahead of the PtGABBIE fields
- remove the now redundant standalone optional data card from the preview column layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5a3b016a4832da3c387b66a178a41