### PR TITLE
Expand zone overview card width

### DIFF
--- a/index.html
+++ b/index.html
@@ -348,7 +348,7 @@
                             </button>
                         </div>
                     </div>
-                    <div class="card zone-summary-table-container">
+                    <div class="card zone-summary-table-container layout-full">
                         <div class="card-header">
                             <h2 class="card-title" data-i18n="Zonenübersicht">Zonenübersicht</h2>
                         </div>


### PR DESCRIPTION
## Summary
- adjust the zone overview card in the generator view to span the full preview column width

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5a4e417b0832da9bfd06a48f04caf