### PR TITLE
Adjust zone overview width

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2113,23 +2113,27 @@ h3.section-title.collapsed::after {
                         height: 1.2em;
                         }
 .zone-summary-table-container {
-			margin-top: 0;
-			padding: 0;
-			border: none;
-			background-color: transparent;
-			text-align: center;
-			display: flex;
-			flex-direction: column;
-			}
-			.zone-summary-table-wrapper {
-			overflow-x: auto;
-			margin-top: 1rem;
-			margin-bottom: .5rem;
-			background-color: var(--card-bg-color);
-			padding: .5rem;
-			border-radius: var(--border-radius);
-			border: 1px solid var(--border-color);
-			}
+                        margin-top: 0;
+                        padding: 0;
+                        border: none;
+                        background-color: transparent;
+                        text-align: center;
+                        display: flex;
+                        flex-direction: column;
+                        align-items: stretch;
+                        width: 100%;
+                        }
+                        .zone-summary-table-wrapper {
+                        overflow-x: auto;
+                        margin-top: 1rem;
+                        margin-bottom: .5rem;
+                        background-color: var(--card-bg-color);
+                        padding: .5rem;
+                        border-radius: var(--border-radius);
+                        border: 1px solid var(--border-color);
+                        width: 100%;
+                        box-sizing: border-box;
+                        }
 			#zoneSummaryTable {
 			width: 100%;
 			border-collapse: collapse;


### PR DESCRIPTION
## Summary
- stretch the zone overview card to the full available width in the generator view
- ensure the table wrapper uses the full width so it aligns with the visual preview card

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5aa7db89c832d8d38c81484a6bceb