### PR TITLE
Allow generator view to use full width

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -916,6 +916,7 @@ body:not(.is-generator-view) .app-main {
     box-sizing: border-box;
 }
 
+#generatorView.app-container,
 #resourcesView.app-container {
     max-width: none;
 }


### PR DESCRIPTION
## Summary
- allow the generator view container to expand across the full viewport width by removing its max-width constraint

## Testing
- not run (static CSS change)


------
https://chatgpt.com/codex/tasks/task_e_68d5abefeb58832dad7055b56e7e7580