### PR TITLE
Fix BVBS note textarea overflow

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3615,6 +3615,7 @@ body[data-theme="dark"] #bvbsListTable tbody tr.is-selected:hover {
 #bvbsListTable .bvbs-note-input {
     width: 100%;
     min-height: 2.25rem;
+    box-sizing: border-box;
     border: 1px solid rgba(148, 163, 184, 0.6);
     border-radius: 8px;
     padding: 0.45rem 0.6rem;


### PR DESCRIPTION
## Summary
- ensure the BVBS note textarea respects its table cell width by using border-box sizing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6532b6d60832dadc3e835a35cb155