### PR TITLE
Fix 2D view after toggling from 3D

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -3480,6 +3480,11 @@ document.addEventListener('DOMContentLoaded', () => {
                                 document.getElementById('viewer3dContainer').style.display = 'none';
                                 document.getElementById('view2dBtn').classList.add('active');
                                 document.getElementById('view3dBtn').classList.remove('active');
+                                if (typeof window.requestAnimationFrame === 'function') {
+                                    window.requestAnimationFrame(() => drawCagePreview());
+                                } else {
+                                    drawCagePreview();
+                                }
                             });
 
                             document.getElementById('view3dBtn')?.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- refresh the cage SVG preview when switching back to the 2D view so it uses the visible container size

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d66222fe9c832d9d3c126a4f8de740