### PR TITLE
Enable editing BVBS entries in configurator

### DIFF
--- a/index.html
+++ b/index.html
@@ -1573,6 +1573,7 @@
                                             <th data-column-key="selection" class="bvbs-selection-header">
                                                 <input type="checkbox" id="bvbsSelectAllCheckbox" class="bvbs-selection-checkbox" aria-label="Alle sichtbaren Zeilen auswählen" title="Alle sichtbaren Zeilen auswählen">
                                             </th>
+                                            <th data-column-key="actions" data-i18n="Aktionen">Aktionen</th>
                                             <th data-column-key="displayType" data-sort-key="displayType" data-i18n="Typ">Typ</th>
                                             <th data-column-key="project" data-sort-key="project" data-i18n="Projekt">Projekt</th>
                                             <th data-column-key="plan" data-sort-key="plan" data-i18n="Plan">Plan</th>

--- a/styles.css
+++ b/styles.css
@@ -3541,6 +3541,26 @@ body[data-theme="dark"] .stirrup-form-preview__canvas {
     cursor: pointer;
 }
 
+#bvbsListTable .bvbs-actions-cell {
+    text-align: center;
+    white-space: nowrap;
+    padding: 0.5rem;
+}
+
+#bvbsListTable .bvbs-actions-cell .bvbs-edit-entry-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.875rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 0.5rem;
+}
+
+#bvbsListTable .bvbs-actions-cell .bvbs-edit-entry-btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
 #bvbsListTable thead th.bvbs-selection-header,
 #bvbsListTable tbody td.bvbs-selection-cell {
     padding: 0.25rem;


### PR DESCRIPTION
## Summary
- add an actions column to the BVBS table so entries can be opened in the appropriate configurator
- dispatch BVBS entry update events from the BF2D configurator when saving and refresh the list row data
- style the new actions column for the inline edit buttons

## Testing
- Manual UI verification

------
https://chatgpt.com/codex/tasks/task_e_68da2fe24b34832d918eac2196c43f16