### PR TITLE
Persist bending forms in SQLite and add database viewer

### DIFF
--- a/database-viewer.js
+++ b/database-viewer.js
@@ -1,0 +1,193 @@
+(function () {
+    const viewElement = document.getElementById('databaseViewerView');
+
+    const noop = () => {};
+
+    if (!viewElement) {
+        window.databaseViewer = {
+            onShow: noop,
+            refresh: noop
+        };
+        return;
+    }
+
+    const elements = {
+        tableBody: document.getElementById('databaseViewerTableBody'),
+        status: document.getElementById('databaseViewerStatus'),
+        refreshButton: document.getElementById('databaseViewerRefreshBtn')
+    };
+
+    let isLoading = false;
+    let lastEntries = [];
+
+    function translate(key, fallback, replacements = {}) {
+        if (typeof window !== 'undefined' && window.i18n && typeof window.i18n.t === 'function') {
+            const translated = window.i18n.t(key, replacements);
+            if (translated && translated !== key) {
+                return translated;
+            }
+        }
+        let text = fallback ?? key;
+        if (text && replacements && typeof replacements === 'object') {
+            Object.keys(replacements).forEach(name => {
+                const value = replacements[name];
+                text = text.replace(new RegExp(`{${name}}`, 'g'), value);
+            });
+        }
+        return text;
+    }
+
+    function setStatus(text, type = 'info') {
+        if (!elements.status) {
+            return;
+        }
+        elements.status.textContent = text || '';
+        elements.status.classList.toggle('is-loading', type === 'loading');
+        elements.status.classList.toggle('is-error', type === 'error');
+    }
+
+    function formatUpdatedAt(value) {
+        if (!value) {
+            return translate('DatabaseViewer.Table.UpdatedUnknown', 'Unbekannt');
+        }
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) {
+            return String(value);
+        }
+        try {
+            return date.toLocaleString(undefined, {
+                dateStyle: 'short',
+                timeStyle: 'medium'
+            });
+        } catch (error) {
+            return date.toISOString();
+        }
+    }
+
+    function countEntries(value) {
+        if (value === null || value === undefined) {
+            return 0;
+        }
+        if (Array.isArray(value)) {
+            return value.length;
+        }
+        if (typeof value === 'object') {
+            return Object.keys(value).length;
+        }
+        return 1;
+    }
+
+    function renderEmptyRow() {
+        if (!elements.tableBody) {
+            return;
+        }
+        const row = document.createElement('tr');
+        const cell = document.createElement('td');
+        cell.colSpan = 4;
+        cell.textContent = translate('DatabaseViewer.Empty', 'Keine gespeicherten Daten vorhanden.');
+        row.appendChild(cell);
+        elements.tableBody.appendChild(row);
+    }
+
+    function renderEntries(entries) {
+        if (!elements.tableBody) {
+            return;
+        }
+        elements.tableBody.innerHTML = '';
+        if (!Array.isArray(entries) || entries.length === 0) {
+            renderEmptyRow();
+            return;
+        }
+
+        entries.forEach(entry => {
+            const row = document.createElement('tr');
+            const keyCell = document.createElement('td');
+            keyCell.textContent = entry.key || '';
+            row.appendChild(keyCell);
+
+            const countCell = document.createElement('td');
+            countCell.textContent = String(countEntries(entry.value));
+            row.appendChild(countCell);
+
+            const updatedCell = document.createElement('td');
+            updatedCell.textContent = formatUpdatedAt(entry.updatedAt);
+            row.appendChild(updatedCell);
+
+            const detailsCell = document.createElement('td');
+            const details = document.createElement('details');
+            const summary = document.createElement('summary');
+            summary.textContent = translate('DatabaseViewer.Details.Toggle', 'Details anzeigen');
+            details.appendChild(summary);
+            const pre = document.createElement('pre');
+            pre.className = 'servicebus-history-details-pre';
+            try {
+                pre.textContent = JSON.stringify(entry.value, null, 2);
+            } catch (error) {
+                pre.textContent = String(entry.value);
+            }
+            details.appendChild(pre);
+            detailsCell.appendChild(details);
+            row.appendChild(detailsCell);
+
+            elements.tableBody.appendChild(row);
+        });
+    }
+
+    async function loadEntries() {
+        if (isLoading) {
+            return;
+        }
+        isLoading = true;
+        if (elements.refreshButton) {
+            elements.refreshButton.disabled = true;
+        }
+        setStatus(translate('DatabaseViewer.Status.Loading', 'Lade gespeicherte Daten…'), 'loading');
+
+        try {
+            const response = await fetch('/api/bending-forms/storage', {
+                method: 'GET',
+                headers: {
+                    'Accept': 'application/json'
+                }
+            });
+            if (!response.ok) {
+                throw new Error(`Request failed with status ${response.status}`);
+            }
+            const data = await response.json();
+            const entries = Array.isArray(data?.entries) ? data.entries : [];
+            lastEntries = entries;
+            renderEntries(entries);
+            if (entries.length === 0) {
+                setStatus(translate('DatabaseViewer.Status.Empty', 'Keine gespeicherten Daten gefunden.'), 'info');
+            } else {
+                setStatus(translate('DatabaseViewer.Status.Success', 'Daten erfolgreich geladen.'), 'info');
+            }
+        } catch (error) {
+            console.error('Failed to load bending form storage snapshot', error);
+            setStatus(translate('DatabaseViewer.Error.Load', 'Daten konnten nicht geladen werden.'), 'error');
+            renderEntries(lastEntries);
+        } finally {
+            isLoading = false;
+            if (elements.refreshButton) {
+                elements.refreshButton.disabled = false;
+            }
+        }
+    }
+
+    if (elements.refreshButton) {
+        elements.refreshButton.addEventListener('click', () => {
+            loadEntries();
+        });
+    }
+
+    window.databaseViewer = {
+        onShow() {
+            if (!lastEntries.length) {
+                loadEntries();
+            }
+        },
+        refresh() {
+            loadEntries();
+        }
+    };
+})();

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
         <link rel="stylesheet" href="styles.css">
         <script src="i18n.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
+        <script src="storage-sync.js" defer></script>
         <script type="importmap">
             {
               "imports": {
@@ -25,6 +26,7 @@
         <script src="bfma-configurator.js" defer></script>
         <script src="bf3d-configurator.js" defer></script>
         <script src="service-bus-history.js" defer></script>
+        <script src="database-viewer.js" defer></script>
         <script src="production.js" defer></script>
         <script src="bvbs-list.js" defer></script>
         <script type="module" src="viewer3d.js" defer></script>
@@ -51,6 +53,12 @@
                                 <path d="M4 6l8 3 8-3V4l-8 3-8-3v2zm0 4l8 3 8-3v-2l-8 3-8-3v2zm0 4l8 3 8-3v-2l-8 3-8-3v2z" />
                             </svg>
                             <span class="sidebar-text" data-i18n="ServiceBusHistory.Nav">Service-Bus-Archiv</span>
+                        </button>
+                        <button id="showDatabaseViewerBtn" class="sidebar-link" data-view-target="databaseViewerView" data-i18n-title="DatabaseViewer.Nav" title="Datenbank">
+                            <svg viewBox="0 0 24 24" aria-hidden="true">
+                                <path d="M12 3c-4.97 0-9 1.79-9 4v10c0 2.21 4.03 4 9 4s9-1.79 9-4V7c0-2.21-4.03-4-9-4zm0 2c3.86 0 7 1.12 7 2s-3.14 2-7 2-7-1.12-7-2 3.14-2 7-2zm0 14c-3.86 0-7-1.12-7-2v-1.5c1.57 1.1 4.27 1.5 7 1.5s5.43-.4 7-1.5V17c0 .88-3.14 2-7 2zm0-4c-3.86 0-7-1.12-7-2v-1.5c1.57 1.1 4.27 1.5 7 1.5s5.43-.4 7-1.5V13c0 .88-3.14 2-7 2z" />
+                            </svg>
+                            <span class="sidebar-text" data-i18n="DatabaseViewer.Nav">Datenbank</span>
                         </button>
                         <div class="sidebar-submenu" data-submenu data-submenu-views="bf2dView,bf3dView,bfmaView">
                             <button type="button" class="sidebar-link sidebar-submenu-toggle" data-submenu-toggle aria-expanded="false" data-i18n-title="Biegeformen" title="Biegeformen">
@@ -1557,6 +1565,38 @@
                                 <button type="button" class="btn-secondary" id="serviceBusHistoryNextBtn" data-i18n="ServiceBusHistory.Pagination.Next">Weiter</button>
                             </div>
                             <div class="servicebus-history-pagination-info" id="serviceBusHistoryPaginationInfo"></div>
+                        </div>
+                    </div>
+                </div>
+                <div id="databaseViewerView" class="app-container" style="display:none;">
+                    <div class="card">
+                        <div class="card-header">
+                            <h2 class="card-title" data-i18n="DatabaseViewer.Title">Datenbank-Viewer</h2>
+                            <div class="button-group">
+                                <button type="button" class="btn-secondary" id="databaseViewerRefreshBtn" data-i18n="DatabaseViewer.Actions.Refresh">Aktualisieren</button>
+                            </div>
+                        </div>
+                        <div class="card-body">
+                            <p class="card-subtitle" data-i18n="DatabaseViewer.Description">Überblick über gespeicherte Biegeformen und Matten im Server-Speicher.</p>
+                            <div id="databaseViewerStatus" class="info-text" aria-live="polite"></div>
+                        </div>
+                    </div>
+                    <div class="card">
+                        <div class="card-header">
+                            <h3 class="card-title" data-i18n="DatabaseViewer.Table.Title">Gespeicherte Schlüssel</h3>
+                        </div>
+                        <div class="production-table-wrapper">
+                            <table class="full-width-table" id="databaseViewerTable">
+                                <thead>
+                                    <tr>
+                                        <th data-i18n="DatabaseViewer.Table.Key">Schlüssel</th>
+                                        <th data-i18n="DatabaseViewer.Table.Count">Einträge</th>
+                                        <th data-i18n="DatabaseViewer.Table.Updated">Zuletzt aktualisiert</th>
+                                        <th data-i18n="DatabaseViewer.Table.Details">Details</th>
+                                    </tr>
+                                </thead>
+                                <tbody id="databaseViewerTableBody"></tbody>
+                            </table>
                         </div>
                     </div>
                 </div>

--- a/lang/cz.json
+++ b/lang/cz.json
@@ -507,5 +507,21 @@
   "ServiceBusHistory.Value.AnySubscription": "Všechny odběry",
   "ServiceBusHistory.Value.UnknownTopic": "Bez tématu",
   "ServiceBusHistory.Value.UnknownSubscription": "Bez odběru",
-  "ServiceBusHistory.Value.Empty": "—"
+  "ServiceBusHistory.Value.Empty": "—",
+  "DatabaseViewer.Nav": "Databáze",
+  "DatabaseViewer.Title": "Prohlížeč databáze",
+  "DatabaseViewer.Description": "Přehled uložených tvarů ohybů a sítí na serveru.",
+  "DatabaseViewer.Actions.Refresh": "Obnovit",
+  "DatabaseViewer.Table.Title": "Uložené klíče",
+  "DatabaseViewer.Table.Key": "Klíč",
+  "DatabaseViewer.Table.Count": "Záznamy",
+  "DatabaseViewer.Table.Updated": "Naposledy aktualizováno",
+  "DatabaseViewer.Table.UpdatedUnknown": "Neznámé",
+  "DatabaseViewer.Table.Details": "Podrobnosti",
+  "DatabaseViewer.Details.Toggle": "Zobrazit podrobnosti",
+  "DatabaseViewer.Empty": "Žádná uložená data.",
+  "DatabaseViewer.Status.Loading": "Načítání uložených dat…",
+  "DatabaseViewer.Status.Empty": "Nebyla nalezena žádná uložená data.",
+  "DatabaseViewer.Status.Success": "Data byla úspěšně načtena.",
+  "DatabaseViewer.Error.Load": "Data se nepodařilo načíst."
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -532,5 +532,21 @@
   "ServiceBusHistory.Value.AnySubscription": "Alle Subscriptions",
   "ServiceBusHistory.Value.UnknownTopic": "Ohne Topic",
   "ServiceBusHistory.Value.UnknownSubscription": "Ohne Subscription",
-  "ServiceBusHistory.Value.Empty": "—"
+  "ServiceBusHistory.Value.Empty": "—",
+  "DatabaseViewer.Nav": "Datenbank",
+  "DatabaseViewer.Title": "Datenbank-Viewer",
+  "DatabaseViewer.Description": "Überblick über gespeicherte Biegeformen und Matten im Server-Speicher.",
+  "DatabaseViewer.Actions.Refresh": "Aktualisieren",
+  "DatabaseViewer.Table.Title": "Gespeicherte Schlüssel",
+  "DatabaseViewer.Table.Key": "Schlüssel",
+  "DatabaseViewer.Table.Count": "Einträge",
+  "DatabaseViewer.Table.Updated": "Zuletzt aktualisiert",
+  "DatabaseViewer.Table.UpdatedUnknown": "Unbekannt",
+  "DatabaseViewer.Table.Details": "Details",
+  "DatabaseViewer.Details.Toggle": "Details anzeigen",
+  "DatabaseViewer.Empty": "Keine gespeicherten Daten vorhanden.",
+  "DatabaseViewer.Status.Loading": "Lade gespeicherte Daten…",
+  "DatabaseViewer.Status.Empty": "Keine gespeicherten Daten gefunden.",
+  "DatabaseViewer.Status.Success": "Daten erfolgreich geladen.",
+  "DatabaseViewer.Error.Load": "Daten konnten nicht geladen werden."
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -514,5 +514,21 @@
   "ServiceBusHistory.Value.AnySubscription": "All subscriptions",
   "ServiceBusHistory.Value.UnknownTopic": "No topic",
   "ServiceBusHistory.Value.UnknownSubscription": "No subscription",
-  "ServiceBusHistory.Value.Empty": "—"
+  "ServiceBusHistory.Value.Empty": "—",
+  "DatabaseViewer.Nav": "Database",
+  "DatabaseViewer.Title": "Database viewer",
+  "DatabaseViewer.Description": "Overview of stored bending shapes and meshes on the server.",
+  "DatabaseViewer.Actions.Refresh": "Refresh",
+  "DatabaseViewer.Table.Title": "Stored keys",
+  "DatabaseViewer.Table.Key": "Key",
+  "DatabaseViewer.Table.Count": "Entries",
+  "DatabaseViewer.Table.Updated": "Last updated",
+  "DatabaseViewer.Table.UpdatedUnknown": "Unknown",
+  "DatabaseViewer.Table.Details": "Details",
+  "DatabaseViewer.Details.Toggle": "Show details",
+  "DatabaseViewer.Empty": "No stored data available.",
+  "DatabaseViewer.Status.Loading": "Loading stored data…",
+  "DatabaseViewer.Status.Empty": "No stored data found.",
+  "DatabaseViewer.Status.Success": "Data loaded successfully.",
+  "DatabaseViewer.Error.Load": "Failed to load data."
 }

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -507,5 +507,21 @@
   "ServiceBusHistory.Value.AnySubscription": "Wszystkie subskrypcje",
   "ServiceBusHistory.Value.UnknownTopic": "Bez tematu",
   "ServiceBusHistory.Value.UnknownSubscription": "Bez subskrypcji",
-  "ServiceBusHistory.Value.Empty": "—"
+  "ServiceBusHistory.Value.Empty": "—",
+  "DatabaseViewer.Nav": "Baza danych",
+  "DatabaseViewer.Title": "Podgląd bazy danych",
+  "DatabaseViewer.Description": "Przegląd zapisanych kształtów gięcia i siatek na serwerze.",
+  "DatabaseViewer.Actions.Refresh": "Odśwież",
+  "DatabaseViewer.Table.Title": "Zapisane klucze",
+  "DatabaseViewer.Table.Key": "Klucz",
+  "DatabaseViewer.Table.Count": "Elementy",
+  "DatabaseViewer.Table.Updated": "Ostatnia aktualizacja",
+  "DatabaseViewer.Table.UpdatedUnknown": "Nieznane",
+  "DatabaseViewer.Table.Details": "Szczegóły",
+  "DatabaseViewer.Details.Toggle": "Pokaż szczegóły",
+  "DatabaseViewer.Empty": "Brak zapisanych danych.",
+  "DatabaseViewer.Status.Loading": "Ładowanie zapisanych danych…",
+  "DatabaseViewer.Status.Empty": "Nie znaleziono zapisanych danych.",
+  "DatabaseViewer.Status.Success": "Dane pomyślnie załadowane.",
+  "DatabaseViewer.Error.Load": "Nie udało się wczytać danych."
 }

--- a/storage-sync.js
+++ b/storage-sync.js
@@ -1,0 +1,164 @@
+(function () {
+    const STORAGE_CONFIG = {
+        bf2dSavedForms: {
+            event: 'bf2dSavedFormsUpdated',
+            getNames: value => Object.keys(value || {})
+        },
+        bf3dSavedForms: {},
+        bf3dSavedShapes: {},
+        bfmaSavedMeshes: {
+            event: 'bfmaSavedMeshesUpdated',
+            getNames: value => Object.keys(value || {})
+        }
+    };
+
+    const API_ENDPOINT = '/api/bending-forms/storage';
+
+    let snapshotPromise = null;
+    let snapshotLoaded = false;
+
+    function dispatchStorageEvent(key, value) {
+        if (typeof window === 'undefined' || typeof window.dispatchEvent !== 'function') {
+            return;
+        }
+        const config = STORAGE_CONFIG[key];
+        if (!config || !config.event) {
+            return;
+        }
+        try {
+            const detail = { key };
+            if (typeof config.getNames === 'function') {
+                try {
+                    detail.names = config.getNames(value);
+                } catch (error) {
+                    detail.names = [];
+                }
+            }
+            window.dispatchEvent(new CustomEvent(config.event, { detail }));
+        } catch (error) {
+            console.warn('Failed to dispatch storage sync event', error);
+        }
+    }
+
+    function setLocalStorageKey(key, value) {
+        if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+            dispatchStorageEvent(key, value);
+            return;
+        }
+        try {
+            if (value === null || value === undefined) {
+                window.localStorage.removeItem(key);
+            } else {
+                window.localStorage.setItem(key, JSON.stringify(value));
+            }
+        } catch (error) {
+            console.warn(`Failed to update localStorage for ${key}`, error);
+        }
+        dispatchStorageEvent(key, value);
+    }
+
+    async function loadSnapshot() {
+        if (snapshotLoaded) {
+            return;
+        }
+        if (snapshotPromise) {
+            return snapshotPromise;
+        }
+        snapshotPromise = fetch(API_ENDPOINT, {
+            method: 'GET',
+            headers: {
+                'Accept': 'application/json'
+            }
+        })
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error(`Failed to load storage snapshot: ${response.status}`);
+                }
+                return response.json();
+            })
+            .then(data => {
+                if (!data || !Array.isArray(data.entries)) {
+                    return;
+                }
+                data.entries.forEach(entry => {
+                    if (!entry || typeof entry.key !== 'string') {
+                        return;
+                    }
+                    if (!Object.prototype.hasOwnProperty.call(STORAGE_CONFIG, entry.key)) {
+                        return;
+                    }
+                    setLocalStorageKey(entry.key, entry.value ?? null);
+                });
+            })
+            .catch(error => {
+                console.error('Failed to load bending form storage snapshot', error);
+            })
+            .finally(() => {
+                snapshotLoaded = true;
+            });
+        return snapshotPromise;
+    }
+
+    async function pushUpdate(key, value) {
+        const payload = {
+            data: {
+                [key]: value
+            }
+        };
+        try {
+            const response = await fetch(API_ENDPOINT, {
+                method: 'PUT',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Accept': 'application/json'
+                },
+                body: JSON.stringify(payload)
+            });
+            if (!response.ok) {
+                throw new Error(`Failed to persist storage snapshot: ${response.status}`);
+            }
+            const data = await response.json();
+            if (!data || !Array.isArray(data.entries)) {
+                return;
+            }
+            const entry = data.entries.find(item => item && item.key === key);
+            if (entry) {
+                setLocalStorageKey(entry.key, entry.value ?? null);
+            }
+        } catch (error) {
+            console.error('Failed to persist bending form storage snapshot', error);
+        }
+    }
+
+    function normalizeValueForSync(value) {
+        if (value === null || value === undefined) {
+            return null;
+        }
+        if (typeof value !== 'object') {
+            return value;
+        }
+        if (Array.isArray(value)) {
+            return value;
+        }
+        const entries = Object.keys(value);
+        if (entries.length === 0) {
+            return null;
+        }
+        return value;
+    }
+
+    window.bendingFormStorageSync = {
+        syncKey(key, value) {
+            if (!Object.prototype.hasOwnProperty.call(STORAGE_CONFIG, key)) {
+                return Promise.resolve(false);
+            }
+            const normalized = normalizeValueForSync(value);
+            return pushUpdate(key, normalized);
+        },
+        ensureSnapshotLoaded() {
+            return loadSnapshot();
+        }
+    };
+
+    loadSnapshot();
+})();


### PR DESCRIPTION
## Summary
- persist saved bending form data in a new SQLite table and expose REST endpoints for syncing forms
- add a client-side storage synchronizer to push local bending form changes to the backend and refresh BF2D/BFMA configurators
- introduce a database viewer screen to inspect stored form data and extend translations/navigation to surface it in the UI

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da4f24b2f0832d9a2fe9aa981916af