### PR TITLE
Fix overflowing form input layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -374,6 +374,7 @@ select {
     align-items: center;
     margin-bottom: 1rem;
     position: relative;
+    min-width: 0;
 }
 
 .form-group label {
@@ -385,8 +386,10 @@ select {
 }
 
 .form-group input,
-.form-group select {
-    flex-grow: 1;
+.form-group select,
+.form-group textarea {
+    flex: 1 1 0;
+    min-width: 0;
 }
 
 .form-group .input-with-dropdown {


### PR DESCRIPTION
## Summary
- ensure form group containers can shrink within responsive layouts
- allow text, number, and textarea controls to flex without overlapping neighbouring fields

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68da561218dc832dac9174fa82c63dcc