### PR TITLE
Improve responsive layout for form inputs

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -369,26 +369,24 @@ select {
 			box-shadow: 0 0 0 .2rem rgba(var(--primary-color-rgb), .25);
 			}
 .form-group {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.5rem;
     margin-bottom: 1rem;
     position: relative;
     min-width: 0;
 }
 
 .form-group label {
-    flex: 0 0 130px;
-    padding-right: 1rem;
-    text-align: right;
     font-weight: 500;
     color: var(--text-muted-color);
+    text-align: left;
 }
 
 .form-group input,
 .form-group select,
 .form-group textarea {
-    flex: 1 1 0;
+    width: 100%;
     min-width: 0;
 }
 
@@ -396,13 +394,26 @@ select {
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-    flex: 1;
+    width: 100%;
 }
 
 .form-group .input-with-dropdown > input,
 .form-group .input-with-dropdown > button,
 .form-group .input-with-dropdown > select {
     width: 100%;
+}
+
+@media (min-width: 768px) {
+    .form-group {
+        grid-template-columns: minmax(130px, auto) minmax(0, 1fr);
+        align-items: center;
+        column-gap: 1rem;
+    }
+
+    .form-group label {
+        text-align: right;
+        padding-right: 1rem;
+    }
 }
 
 .saved-form-button {
@@ -2033,27 +2044,28 @@ h3.section-title.collapsed::after {
 			.info-text.error-message {
 			color: var(--danger-color);
 			}
-			.form-group .input-feedback {
-			position: absolute;
-			bottom: -1em;
-			left: 130px;
-			width: calc(100% - 130px);
-			font-size: .7em;
-			padding: 0 .6rem;
-			box-sizing: border-box;
-			white-space: nowrap;
-			overflow: hidden;
-			text-overflow: ellipsis;
-			height: 0;
-			opacity: 0;
-			transition: height .2s ease-out, opacity .2s ease-out;
-			}
-			.form-group .input-feedback.error-message,
-			.form-group .input-feedback.warning-message,
-			.form-group .input-feedback.success-message {
-			height: auto;
-			opacity: 1;
-			}
+                        .form-group .input-feedback {
+                        grid-column: 1 / -1;
+                        font-size: .75rem;
+                        line-height: 1.4;
+                        padding: 0;
+                        margin: 0;
+                        overflow: hidden;
+                        height: 0;
+                        opacity: 0;
+                        transition: height .2s ease-out, opacity .2s ease-out;
+                        }
+                        @media (min-width: 768px) {
+                        .form-group .input-feedback {
+                        grid-column: 2;
+                        }
+                        }
+                        .form-group .input-feedback.error-message,
+                        .form-group .input-feedback.warning-message,
+                        .form-group .input-feedback.success-message {
+                        height: auto;
+                        opacity: 1;
+                        }
                         .output-area {
                         display: flex;
                         flex-direction: column;


### PR DESCRIPTION
## Summary
- switch the global form group layout to a responsive CSS grid so labels and fields stack cleanly on narrow cards
- update inline feedback styling to align with the new grid layout without overlapping other controls

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da57c2e2e8832d928cec776ec2b23e