### PR TITLE
Adjust generator column widths

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -966,7 +966,7 @@ body:not(.is-generator-view) .app-main {
 
 .main-grid {
     display: grid;
-    grid-template-columns: minmax(360px, 440px) minmax(0, 1fr);
+    grid-template-columns: minmax(420px, 520px) minmax(0, 1fr);
     gap: 1.5rem;
     align-items: start;
     width: 100%;
@@ -975,8 +975,8 @@ body:not(.is-generator-view) .app-main {
 .input-column {
     display: flex;
     flex-direction: column;
-    min-width: 360px;
-    max-width: 440px;
+    min-width: 420px;
+    max-width: 520px;
 }
 
 .input-column .input-scroll-container {


### PR DESCRIPTION
## Summary
- widen the generator view's input column to provide more space for controls
- reduce the relative width of the preview column by increasing the first column sizing constraints

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da7402ca20832d90bce9fcb961e3ac