### PR TITLE
Reduce width of stirrup zone inputs

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1895,14 +1895,16 @@ h3.section-title.collapsed::after {
 			padding: .4rem .6rem;
 			position: relative;
 			}
-			.zone-table-wrapper .full-width-table input[type="number"],
-			.zone-table-wrapper .full-width-table select {
-			width: 100%;
-			padding: .3rem .5rem;
-			box-sizing: border-box;
-			font-size: .85rem;
-			margin-bottom: 0;
-			}
+.zone-table-wrapper .full-width-table input[type="number"],
+.zone-table-wrapper .full-width-table select {
+    width: 70%;
+    padding: .3rem .5rem;
+    box-sizing: border-box;
+    font-size: .85rem;
+    margin-bottom: 0;
+    margin-left: auto;
+    margin-right: auto;
+}
 			.zone-table-wrapper .full-width-table .form-group label {
 			display: none;
 			}


### PR DESCRIPTION
## Summary
- shrink stirrup zone table inputs to 70% width to allow narrower columns
- center the inputs within their cells for a tidier layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da7534f434832dac60f8fc520ccd84