### PR TITLE
Fix layout of optional data selector

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -464,14 +464,14 @@ select {
     }
 
     .generator-inputs .input-with-dropdown {
-        flex-direction: row;
+        flex-direction: column;
         align-items: stretch;
         gap: 0.75rem;
     }
 
     .generator-inputs .input-with-dropdown > button {
-        width: auto;
-        white-space: nowrap;
+        width: 100%;
+        white-space: normal;
     }
 }
 


### PR DESCRIPTION
## Summary
- keep the saved form picker button stacked below its input across breakpoints
- allow the picker button text to wrap so its label remains readable

## Testing
- npm test *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68da8cc4c78c832d98402b8f6811e4c9