### PR TITLE
Persist resource data to database snapshot

### DIFF
--- a/server.js
+++ b/server.js
@@ -48,7 +48,8 @@ const BENDING_FORM_STORAGE_KEYS = new Set([
     'bf2dSavedForms',
     'bf3dSavedForms',
     'bf3dSavedShapes',
-    'bfmaSavedMeshes'
+    'bfmaSavedMeshes',
+    'bvbsResources'
 ]);
 
 const databaseInitPromise = new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- include the resources storage key in the backend snapshot that feeds the database viewer
- synchronize resource updates through the storage sync helper and react to incoming updates
- wait for the persisted snapshot before bootstrapping the resources UI to ensure fresh data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da9403661c832d814a9948dc3a91df