### PR TITLE
Improve visual separation of stirrup zones

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -2535,6 +2535,9 @@ function generateZoneSummary(zones) {
                                 if (index < zonesPerLabel) {
                                     row.classList.add('first-label-zone');
                                 }
+                                if (index === zonesPerLabel) {
+                                    row.classList.add('label-separator-row');
+                                }
                                 if (highlightedZoneDisplayIndex === displayIndex) {
                                     row.classList.add('focused-zone-form');
                                 }
@@ -2807,6 +2810,7 @@ function triggerPreviewUpdateDebounced() {
                                 const g2 = document.createElement('th');
                                 g2.textContent = 'Code 2';
                                 g2.colSpan = secondGroup.length;
+                                g2.classList.add('second-label-start');
                                 groupRow.appendChild(g2);
                                 tbody.appendChild(groupRow);
                             }
@@ -2834,6 +2838,9 @@ function triggerPreviewUpdateDebounced() {
                                     }
                                     if (cellIndex < zonesPerLabel) {
                                         cell.classList.add('first-label-zone');
+                                    }
+                                    if (cellIndex === zonesPerLabel) {
+                                        cell.classList.add('second-label-start');
                                     }
                                     row.appendChild(cell);
                                 });

--- a/styles.css
+++ b/styles.css
@@ -2023,7 +2023,22 @@ div.zone-item-header {
 }
 .zone-table-wrapper .full-width-table tr.first-label-zone,
 #zoneSummaryTable td.first-label-zone {
-    background-color: rgba(var(--primary-color-rgb), .05);
+    background-color: rgba(var(--primary-color-rgb), .12);
+}
+.zone-table-wrapper .full-width-table tr.label-separator-row td,
+.zone-table-wrapper .full-width-table tr.label-separator-row th {
+    border-top: 2px solid rgba(var(--primary-color-rgb), .6);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+.zone-table-wrapper .full-width-table tr.label-separator-row td.zone-index-cell {
+    border-left-color: transparent;
+}
+#zoneSummaryTable th.second-label-start,
+#zoneSummaryTable td.second-label-start {
+    border-left: 2px solid rgba(var(--primary-color-rgb), .6);
+}
+#zoneSummaryTable td.second-label-start {
+    padding-left: calc(var(--spacing-xs, 0.4rem) + 0.15rem);
 }
 .stirrup-zone {
     cursor: pointer;


### PR DESCRIPTION
## Summary
- add a separator class to the stirrup zone table rows when the second label group starts
- apply corresponding styling and stronger shading so the split between zone groups is easier to see
- highlight the same separation inside the zone summary table headers and cells

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68db15aceafc832d81c4eee10145217f