### PR TITLE
Add label preview modal and metadata to production list

### DIFF
--- a/index.html
+++ b/index.html
@@ -1938,6 +1938,31 @@
             </div>
         </div>
 
+        <div id="labelPreviewModal" class="modal-overlay">
+            <div class="modal-content card label-preview-modal">
+                <div class="modal-header card-header">
+                    <h2 class="modal-title card-title" data-i18n="Label Vorschau">Label Vorschau</h2>
+                    <button type="button" class="close-modal-btn" id="labelPreviewCloseButton">
+                        <svg viewBox="0 0 24 24">
+                            <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
+                        </svg>
+                    </button>
+                </div>
+                <div class="modal-body label-preview-body">
+                    <div class="label-preview-image-wrapper">
+                        <img id="labelPreviewImage" class="label-preview-image" alt="">
+                        <div class="label-preview-actions">
+                            <button type="button" id="labelPreviewOpenButton" class="btn-secondary" data-i18n="In neuem Tab öffnen">In neuem Tab öffnen</button>
+                        </div>
+                    </div>
+                    <div class="label-preview-meta">
+                        <h3 class="label-preview-subtitle" data-i18n="Auftragsdetails">Auftragsdetails</h3>
+                        <dl id="labelPreviewDetails" class="label-preview-details"></dl>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <div id="savedOrdersModal" class="modal-overlay">
             <div class="modal-content card">
                 <div class="modal-header card-header">

--- a/styles.css
+++ b/styles.css
@@ -3957,8 +3957,10 @@ body[data-theme="dark"] #bvbsListTable tbody tr.is-selected:hover {
 }
 
 .label-thumbnail {
-    max-width: 150px;
-    max-height: 50px;
+    max-width: 200px;
+    max-height: 80px;
+    width: 100%;
+    height: auto;
     object-fit: contain;
     cursor: pointer;
     transition: transform 0.2s;
@@ -3970,6 +3972,118 @@ body[data-theme="dark"] #bvbsListTable tbody tr.is-selected:hover {
 .label-thumbnail:hover {
     transform: scale(1.1);
     box-shadow: var(--shadow-md);
+}
+
+#productionTable td.label-cell {
+    white-space: normal;
+    vertical-align: top;
+}
+
+.label-preview-button {
+    border: none;
+    background: none;
+    padding: 0;
+    display: block;
+    max-width: 220px;
+    width: 100%;
+    cursor: zoom-in;
+}
+
+.label-preview-button:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+}
+
+.label-preview-button:focus-visible {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 2px;
+}
+
+.label-extra-info {
+    margin: 0.5rem 0 0;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.25rem 0.75rem;
+    font-size: 0.8rem;
+    color: var(--muted-text-color, #6b7280);
+}
+
+.label-extra-info dt {
+    font-weight: 600;
+    margin: 0;
+}
+
+.label-extra-info dd {
+    margin: 0;
+}
+
+.label-preview-modal {
+    max-width: 960px;
+}
+
+.label-preview-body {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: 1fr;
+    align-items: flex-start;
+}
+
+@media (min-width: 768px) {
+    .label-preview-body {
+        grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+    }
+}
+
+.label-preview-image-wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.label-preview-image {
+    width: 100%;
+    height: auto;
+    border-radius: var(--border-radius);
+    border: 1px solid var(--border-color);
+    background-color: #fff;
+    box-shadow: var(--shadow-sm);
+}
+
+.label-preview-actions {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.label-preview-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.label-preview-subtitle {
+    margin: 0;
+    font-size: 1.1rem;
+}
+
+.label-preview-details {
+    margin: 0;
+    display: grid;
+    gap: 0.5rem 1rem;
+    grid-template-columns: auto 1fr;
+    font-size: 0.95rem;
+}
+
+.label-preview-details dt {
+    margin: 0;
+    font-weight: 600;
+    color: var(--text-color);
+}
+
+.label-preview-details dd {
+    margin: 0;
+    color: var(--muted-text-color, #4b5563);
+    white-space: pre-wrap;
 }
 
 .status-badge {


### PR DESCRIPTION
## Summary
- add a dedicated modal to enlarge production labels and review related order information
- persist additional metadata for production items and clean existing storage entries during load
- enrich the label column with inline release/update details and styling for the new preview elements

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68db56b46ab0832d9c07e2c28e197245