### PR TITLE
Add production order comments with database persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -1938,6 +1938,29 @@
             </div>
         </div>
 
+        <div id="productionNoteModal" class="modal-overlay">
+            <div class="modal-content card">
+                <div class="modal-header card-header">
+                    <h2 class="modal-title card-title" data-i18n="Bemerkung bearbeiten">Bemerkung bearbeiten</h2>
+                    <button type="button" class="close-modal-btn" onclick="closeProductionNoteModal()">
+                        <svg viewBox="0 0 24 24">
+                            <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
+                        </svg>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <div class="form-group">
+                        <label for="productionNoteInput" data-i18n="Bemerkung">Bemerkung</label>
+                        <textarea id="productionNoteInput" rows="4"></textarea>
+                    </div>
+                    <div class="button-group" style="justify-content: flex-end; margin-top: 1rem;">
+                        <button type="button" class="btn-secondary" onclick="closeProductionNoteModal()" data-i18n="Abbrechen">Abbrechen</button>
+                        <button type="button" id="productionNoteSaveButton" class="btn-primary" data-i18n="Speichern">Speichern</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <div id="labelPreviewModal" class="modal-overlay">
             <div class="modal-content card label-preview-modal">
                 <div class="modal-header card-header">

--- a/server.js
+++ b/server.js
@@ -49,7 +49,8 @@ const BENDING_FORM_STORAGE_KEYS = new Set([
     'bf3dSavedForms',
     'bf3dSavedShapes',
     'bfmaSavedMeshes',
-    'bvbsResources'
+    'bvbsResources',
+    'bvbsProductionList'
 ]);
 
 const databaseInitPromise = new Promise((resolve, reject) => {
@@ -412,7 +413,7 @@ async function persistServiceBusMessages(messages, context = {}) {
     }
 }
 
-app.use(express.json({ limit: '1mb' }));
+app.use(express.json({ limit: '10mb' }));
 app.use(express.static(STATIC_DIR, { extensions: ['html'] }));
 
 function sanitizeText(value) {

--- a/storage-sync.js
+++ b/storage-sync.js
@@ -23,6 +23,12 @@
                     .map(item => (item && typeof item.name === 'string') ? item.name : null)
                     .filter(name => Boolean(name));
             }
+        },
+        bvbsProductionList: {
+            event: 'bvbsProductionListUpdated',
+            buildDetail: value => ({
+                orderCount: Array.isArray(value) ? value.length : 0
+            })
         }
     };
 

--- a/styles.css
+++ b/styles.css
@@ -3982,6 +3982,49 @@ body[data-theme="dark"] #bvbsListTable tbody tr.is-selected:hover {
     vertical-align: top;
 }
 
+.production-note-cell {
+    white-space: normal;
+}
+
+.production-note {
+    display: flex;
+    gap: 0.5rem;
+    align-items: flex-start;
+}
+
+.production-note-text {
+    flex: 1 1 auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+    color: var(--text-color);
+}
+
+.production-note-edit-button {
+    flex: 0 0 auto;
+    align-self: center;
+    border: 1px solid var(--border-color);
+    border-radius: 0.75rem;
+    background-color: var(--card-bg-color);
+    color: var(--primary-color);
+    padding: 0.35rem 0.85rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.production-note-edit-button:hover,
+.production-note-edit-button:focus-visible {
+    background-color: rgba(var(--primary-color-rgb), 0.08);
+    border-color: rgba(var(--primary-color-rgb), 0.35);
+    color: var(--primary-color);
+    box-shadow: 0 0 0 0.15rem rgba(var(--primary-color-rgb), 0.18);
+}
+
+.production-note-edit-button:focus-visible {
+    outline: none;
+}
+
 .label-preview-button {
     border: none;
     background: none;


### PR DESCRIPTION
## Summary
- add a modal to create and edit production order comments directly from the production list
- sync production orders with the backend storage service and extend the server to persist the list
- style the new comment column and raise the JSON payload limit to handle stored label images

## Testing
- npm start *(fails: dependencies cannot be installed in the restricted environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db7894fc58832da00867a2107b4a6c