### PR TITLE
Fix production order note saving and restyle note button

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3987,9 +3987,7 @@ body[data-theme="dark"] #bvbsListTable tbody tr.is-selected:hover {
 }
 
 .production-note {
-    display: flex;
-    gap: 0.5rem;
-    align-items: flex-start;
+    display: block;
 }
 
 .production-note-text {
@@ -3999,30 +3997,8 @@ body[data-theme="dark"] #bvbsListTable tbody tr.is-selected:hover {
     color: var(--text-color);
 }
 
-.production-note-edit-button {
-    flex: 0 0 auto;
-    align-self: center;
-    border: 1px solid var(--border-color);
-    border-radius: 0.75rem;
-    background-color: var(--card-bg-color);
-    color: var(--primary-color);
-    padding: 0.35rem 0.85rem;
-    font-size: 0.85rem;
-    font-weight: 600;
-    cursor: pointer;
-    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.production-note-edit-button:hover,
-.production-note-edit-button:focus-visible {
-    background-color: rgba(var(--primary-color-rgb), 0.08);
-    border-color: rgba(var(--primary-color-rgb), 0.35);
-    color: var(--primary-color);
-    box-shadow: 0 0 0 0.15rem rgba(var(--primary-color-rgb), 0.18);
-}
-
-.production-note-edit-button:focus-visible {
-    outline: none;
+#productionTable .button-group .table-action-button--note {
+    line-height: 1.2;
 }
 
 .label-preview-button {
@@ -4184,6 +4160,12 @@ body[data-theme="dark"] #bvbsListTable tbody tr.is-selected:hover {
     transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
+.table-action-button__label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    white-space: nowrap;
+}
+
 .table-action-button svg {
     width: 1.1em;
     height: 1.1em;
@@ -4200,6 +4182,22 @@ body[data-theme="dark"] #bvbsListTable tbody tr.is-selected:hover {
     border-color: rgba(var(--primary-color-rgb), 0.35);
     color: var(--primary-color);
     box-shadow: 0 0 0 0.15rem rgba(var(--primary-color-rgb), 0.18);
+}
+
+.table-action-button--note {
+    min-width: auto;
+    padding: 0.45rem 0.85rem;
+    background-color: rgba(var(--primary-color-rgb), 0.08);
+    border-color: rgba(var(--primary-color-rgb), 0.35);
+    color: var(--primary-color);
+}
+
+.table-action-button--note:hover,
+.table-action-button--note:focus-visible {
+    background-color: rgba(var(--primary-color-rgb), 0.18);
+    border-color: rgba(var(--primary-color-rgb), 0.55);
+    color: var(--primary-color);
+    box-shadow: 0 0 0 0.15rem rgba(var(--primary-color-rgb), 0.2);
 }
 
 .table-action-button--start {


### PR DESCRIPTION
## Summary
- ensure production note edits resolve by tracking the active order via its id before persisting
- move the note edit control into the actions column with a dedicated button style so its label is readable

## Testing
- npm start *(fails: missing express dependency in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db7b9621d8832d8c8888b69f88b167