### PR TITLE
Refresh saved Service Bus connections across views

### DIFF
--- a/bvbs-list.js
+++ b/bvbs-list.js
@@ -3875,6 +3875,11 @@
         if (serviceBusConnectionSelect) {
             serviceBusConnectionSelect.addEventListener('change', handleConnectionSelectChange);
             loadConnectionsForSelect();
+            if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+                window.addEventListener('servicebus:connections-updated', () => {
+                    loadConnectionsForSelect();
+                });
+            }
         }
 
         const serviceBusInputs = [

--- a/service-bus-connections.js
+++ b/service-bus-connections.js
@@ -131,6 +131,17 @@
         state.editingConnection = null;
     }
 
+    function notifyConnectionsUpdated() {
+        if (typeof window === 'undefined' || typeof window.dispatchEvent !== 'function') {
+            return;
+        }
+        try {
+            window.dispatchEvent(new CustomEvent('servicebus:connections-updated'));
+        } catch (error) {
+            console.warn('Failed to dispatch connections updated event', error);
+        }
+    }
+
     async function handleFormSubmit(event) {
         event.preventDefault();
         const id = elements.modal.idInput.value;
@@ -159,6 +170,7 @@
 
             closeModal();
             await loadConnections();
+            notifyConnectionsUpdated();
             setStatus(id
                 ? translate('ServiceBusConnections.Status.UpdateSuccess', 'Verbindung aktualisiert.')
                 : translate('ServiceBusConnections.Status.CreateSuccess', 'Verbindung erstellt.'), 'success');
@@ -183,6 +195,7 @@
             const response = await fetch(`/api/service-bus/connections/${id}`, { method: 'DELETE' });
             if (!response.ok) throw new Error('Failed to delete');
             await loadConnections();
+            notifyConnectionsUpdated();
             setStatus(translate('ServiceBusConnections.Status.DeleteSuccess', 'Verbindung gelöscht.'), 'success');
         } catch (error) {
             console.error('Failed to delete connection:', error);


### PR DESCRIPTION
## Summary
- dispatch a custom `servicebus:connections-updated` event after connection CRUD operations
- refresh the BVBS Service Bus connection dropdown when connections are updated elsewhere in the app

## Testing
- npm start *(fails: dependencies unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbdb3279a0832dbe847210c81eaecb