### PR TITLE
Fix service bus connection modal visibility

### DIFF
--- a/service-bus-connections.js
+++ b/service-bus-connections.js
@@ -121,12 +121,14 @@
             elements.modal.connectionStringInput.placeholder = 'Endpoint=sb://...';
         }
         elements.modal.overlay.hidden = false;
+        elements.modal.overlay.classList.add('visible');
         elements.modal.overlay.setAttribute('aria-hidden', 'false');
         elements.modal.nameInput.focus();
     }
 
     function closeModal() {
         elements.modal.overlay.hidden = true;
+        elements.modal.overlay.classList.remove('visible');
         elements.modal.overlay.setAttribute('aria-hidden', 'true');
         state.editingConnection = null;
     }


### PR DESCRIPTION
## Summary
- ensure the service bus connection modal toggles its visibility class when opened or closed so the dialog appears

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcc2760928832db91e4f79e628ba4b