### PR TITLE
Add measurement mode and correct BF3D overhang display

### DIFF
--- a/index.html
+++ b/index.html
@@ -923,6 +923,7 @@
                             <input type="checkbox" id="bf3dToggleOverhangs" checked>
                             <span data-i18n="Überstände">Überstände</span>
                         </label>
+                        <button type="button" id="bf3dMeasureButton" class="btn-secondary bf3d-measure-btn" data-i18n="Messmodus" data-i18n-title="Messmodus Hinweis" title="Messmodus" aria-pressed="false" disabled>Messmodus</button>
                     </div>
                 </div>
             </div>

--- a/lang/cz.json
+++ b/lang/cz.json
@@ -54,6 +54,8 @@
   "Pitch-Abstände": "Rozteče (pitch)",
   "Zonenlängen": "Délky zón",
   "Überstände": "Přesahy",
+  "Messmodus": "Režim měření",
+  "Messmodus Hinweis": "Klikněte na dva body pro změření vzdálenosti. Kliknutím znovu režim vypnete.",
   "(n-1) x Pitch": "(n-1) × rozteč",
   "n x Pitch": "n × rozteč",
   "Beispielkorb laden": "Načíst ukázkový koš",

--- a/lang/de.json
+++ b/lang/de.json
@@ -61,6 +61,8 @@
   "Pitch-Abstände": "Pitch-Abstände",
   "Zonenlängen": "Zonenlängen",
   "Überstände": "Überstände",
+  "Messmodus": "Messmodus",
+  "Messmodus Hinweis": "Klicken Sie auf zwei Punkte, um den Abstand zu messen. Klicken Sie erneut, um den Modus zu verlassen.",
   "(n-1) x Pitch": "(n-1) x Pitch",
   "n x Pitch": "n x Pitch",
   "Beispielkorb laden": "Beispielkorb laden",

--- a/lang/en.json
+++ b/lang/en.json
@@ -61,6 +61,8 @@
   "Pitch-Abstände": "Pitch spacing",
   "Zonenlängen": "Zone lengths",
   "Überstände": "Overhangs",
+  "Messmodus": "Measurement mode",
+  "Messmodus Hinweis": "Click two points to measure the distance. Click again to exit.",
   "(n-1) x Pitch": "(n-1) x Pitch",
   "n x Pitch": "n x Pitch",
   "Beispielkorb laden": "Load sample basket",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -54,6 +54,8 @@
   "Pitch-Abstände": "Odstępy (pitch)",
   "Zonenlängen": "Długości stref",
   "Überstände": "Naddatki",
+  "Messmodus": "Tryb pomiaru",
+  "Messmodus Hinweis": "Kliknij dwa punkty, aby zmierzyć odległość. Kliknij ponownie, aby wyjść.",
   "(n-1) x Pitch": "(n-1) × rozstaw",
   "n x Pitch": "n × rozstaw",
   "Beispielkorb laden": "Wczytaj przykładowy kosz",

--- a/styles.css
+++ b/styles.css
@@ -4349,6 +4349,36 @@ select.status-select.done {
     box-shadow: 0 2px 6px rgba(15, 23, 42, 0.12);
 }
 
+.bf3d-measure-btn {
+    margin-left: 0.75rem;
+    padding: 0.35rem 0.75rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.bf3d-measure-btn.is-active {
+    background: #0d6efd;
+    color: #ffffff;
+    border-color: rgba(13, 110, 253, 0.6);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
+}
+
+.bf3d-preview-3d.is-measuring canvas,
+.bf3d-preview-3d.is-measuring .bf3d-label-layer {
+    cursor: crosshair;
+}
+
+.bf3d-dim-label--measurement {
+    background: rgba(37, 99, 235, 0.94);
+    border-color: rgba(37, 99, 235, 0.42);
+    color: #ffffff;
+}
+
+.bf3d-dim-label--measurement.is-preview {
+    opacity: 0.85;
+}
+
 .bf3d-dim-label--overhang {
     background: rgba(222, 249, 255, 0.9);
     border-color: rgba(13, 148, 170, 0.35);


### PR DESCRIPTION
## Summary
- mark the first and last straight segments as overhangs in the BF3D geometry helper so start and end overhang labels are correct
- add an interactive distance measurement mode to the BF3D 3D preview, including UI controls, raycast picking and dedicated styling
- localize the new measurement toggle and expose it in the configurator UI alongside updated styles

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68dccefe7a80832d9cd03c8fe672c1c6