### PR TITLE
Adjust stirrup zone rendering to show boundary stirrup

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -3019,7 +3019,10 @@ function triggerPreviewUpdateDebounced() {
                                         if (zoneEffectiveLength > 0) {
                                             svgContent += `<rect class="${zoneBgFillClass}" x="${Math.round(zoneStartScaled)}" y="${Math.round(centerY - STIRRUP_HEIGHT_VISUAL / 2)}" width="${Math.round(zoneEffectiveLength * scale)}" height="${Math.round(STIRRUP_HEIGHT_VISUAL)}"/>`;
                                         }
-                                        for (let j = 1; j <= numStirrups; j++) {
+                                        for (let j = 0; j < numStirrups; j++) {
+                                            if (j > 0 && pitch <= 0) {
+                                                break;
+                                            }
                                             const stirrupPos = zoneStart + j * pitch;
                                             if (stirrupPos > zoneLimitMm + 1) {
                                                 break;


### PR DESCRIPTION
## Summary
- start drawing stirrups for each zone from the zone boundary so the overhang transition always shows a stirrup
- prevent duplicate stirrups when the pitch is zero or negative by aborting additional placements

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dce573585c832d957db1324cbf358c