### PR TITLE
Draw standard stirrup at overhang boundary

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -1204,6 +1204,8 @@ function createSavedOrderPreview(order) {
     zones.forEach((zone, index) => {
         const pitch = Number(zone.pitch) || 0;
         const numStirrups = Math.max(0, getEffectiveZoneNum(zone, index));
+        const includeStandardStirrup = index === 0 && numStirrups > 0;
+        const regularStirrupCount = includeStandardStirrup ? numStirrups - 1 : numStirrups;
         const zoneLength = numStirrups > 0 && pitch > 0 ? numStirrups * pitch : 0;
         if (zoneLength > 0) {
             const zoneStartX = paddingX + currentPosition * scale;
@@ -1221,8 +1223,22 @@ function createSavedOrderPreview(order) {
             rect.setAttribute('stroke-width', '0.5');
             backgroundGroup.appendChild(rect);
 
-            for (let j = 1; j <= numStirrups; j++) {
-                const stirrupPos = currentPosition + j * pitch;
+            if (includeStandardStirrup) {
+                const standardLine = document.createElementNS(SVG_NS, 'line');
+                standardLine.setAttribute('x1', zoneStartX.toFixed(2));
+                standardLine.setAttribute('x2', zoneStartX.toFixed(2));
+                standardLine.setAttribute('y1', top.toFixed(2));
+                standardLine.setAttribute('y2', bottom.toFixed(2));
+                standardLine.setAttribute('stroke', zoneColor);
+                standardLine.setAttribute('stroke-width', '1');
+                stirrupGroup.appendChild(standardLine);
+            }
+
+            for (let j = 0; j < regularStirrupCount; j++) {
+                if (pitch <= 0) {
+                    break;
+                }
+                const stirrupPos = currentPosition + (j + 1) * pitch;
                 const stirrupX = paddingX + stirrupPos * scale;
                 if (stirrupX > endX + 0.5) {
                     break;

--- a/viewer3d.js
+++ b/viewer3d.js
@@ -253,6 +253,7 @@ function update(basketData) {
         const dia = Math.max(Number(zone?.dia) || 0, 0);
         const num = Math.max(Number(zone?.num) || 0, 0);
         const pitchMm = Math.max(Number(zone?.pitch) || 0, 0);
+        const includeStandardStirrup = index === 0 && (num > 0 || pitchMm > 0);
 
         const stirrupRadius = Math.max((dia / 2) * scale, 0.0035);
         lastMainBarRadius = Math.max(lastMainBarRadius, stirrupRadius);
@@ -283,7 +284,23 @@ function update(basketData) {
             zoneGroup.add(overlay);
         }
 
+        if (includeStandardStirrup) {
+            const standardStirrup = createStirrup(scaledWidth, scaledHeight, stirrupRadius, stirrupMaterial);
+            standardStirrup.position.z = startReference + zoneStartMm * scale;
+            standardStirrup.userData = standardStirrup.userData || {};
+            standardStirrup.userData.zoneDisplayIndex = displayIndex;
+            standardStirrup.traverse(child => {
+                if (!child) return;
+                child.userData = child.userData || {};
+                child.userData.zoneDisplayIndex = displayIndex;
+            });
+            zoneGroup.add(standardStirrup);
+        }
+
         for (let i = 0; i < num; i++) {
+            if (pitchMm <= 0) {
+                break;
+            }
             const stirrupPosMm = zoneStartMm + (i + 1) * pitchMm;
             if (stirrupPosMm > zoneLimitMm + 0.001) {
                 break;


### PR DESCRIPTION
## Summary
- render the standard stirrup at the initial overhang boundary in the saved order preview so the transition is visible
- add the same standard stirrup at the start of the first zone in the 3D viewer to keep the visuals consistent

## Testing
- ⚠️ `npm install` *(fails with 403 when fetching @azure/service-bus)*

------
https://chatgpt.com/codex/tasks/task_e_68dcf913c830832db6b9be0e45e0a293