### PR TITLE
Fix 2D preview text clipping

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -5079,6 +5079,10 @@ body[data-theme="dark"] .bf2d-machine-list-item {
     height: 100%;
 }
 
+.bf2d-preview-stage > svg {
+    overflow: visible;
+}
+
 #bf2dPreviewSvg {
     display: block;
 }


### PR DESCRIPTION
## Summary
- prevent labels in the 2D preview from being vertically clipped by allowing the SVG to overflow

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd11e9a1b4832d8ee54adb7660b701