### PR TITLE
Show stirrup names in zone overview

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -2815,6 +2815,8 @@ function triggerPreviewUpdateDebounced() {
                             }
 
                             const headerLabels = ["Zone", "Anzahl (n)", "Abstand (p)"];
+                            const stirrupName1 = document.getElementById('buegelname1')?.value.trim() || '';
+                            const stirrupName2 = document.getElementById('buegelname2')?.value.trim() || '';
                             const firstGroup = zonesData.slice(0, zonesPerLabel);
                             const secondGroup = zonesData.slice(zonesPerLabel);
 
@@ -2866,6 +2868,31 @@ function triggerPreviewUpdateDebounced() {
 
                                 tbody.appendChild(row);
                             });
+
+                            const stirrupRow = document.createElement('tr');
+                            const stirrupHeaderCell = document.createElement('th');
+                            const stirrupHeaderLabel = window.i18n?.t?.('Bügelname') || 'Bügelname';
+                            stirrupHeaderCell.textContent = stirrupHeaderLabel;
+                            stirrupRow.appendChild(stirrupHeaderCell);
+
+                            zonesData.forEach((zone, cellIndex) => {
+                                const cell = document.createElement('td');
+                                const isSecondLabelZone = cellIndex >= zonesPerLabel;
+                                const nameForZone = isSecondLabelZone ? stirrupName2 : stirrupName1;
+                                cell.textContent = nameForZone || '-';
+                                if (highlightedZoneDisplayIndex === cellIndex + 1) {
+                                    cell.classList.add('focused-zone-form');
+                                }
+                                if (cellIndex < zonesPerLabel) {
+                                    cell.classList.add('first-label-zone');
+                                }
+                                if (cellIndex === zonesPerLabel) {
+                                    cell.classList.add('second-label-start');
+                                }
+                                stirrupRow.appendChild(cell);
+                            });
+
+                            tbody.appendChild(stirrupRow);
                         }
 			
 			
@@ -3647,7 +3674,26 @@ document.addEventListener('DOMContentLoaded', () => {
                         }
                         });
 
-                            document.getElementById('buegelname2')?.addEventListener('input', () => updateGenerateButtonState());
+                            const buegelname1El = document.getElementById('buegelname1');
+                            if (buegelname1El) {
+                                buegelname1El.addEventListener('input', () => {
+                                    renderZoneSummaryTable();
+                                    if (typeof updateLabelPreview === 'function') {
+                                        updateLabelPreview();
+                                    }
+                                });
+                            }
+
+                            const buegelname2El = document.getElementById('buegelname2');
+                            if (buegelname2El) {
+                                buegelname2El.addEventListener('input', () => {
+                                    updateGenerateButtonState();
+                                    renderZoneSummaryTable();
+                                    if (typeof updateLabelPreview === 'function') {
+                                        updateLabelPreview();
+                                    }
+                                });
+                            }
 			
 			
 			

--- a/lang/cz.json
+++ b/lang/cz.json
@@ -64,6 +64,7 @@
   "Optionale (PREFORM 4.0) Daten": "Volitelná data (PREFORM 4.0)",
   "Bügelname (s) - Zone 1": "Název třmínku (s) - Zóna 1",
   "Bügelname (s) - Zone 2": "Název třmínku (s) - Zóna 2",
+  "Bügelname": "Název třmínku",
   "Rezeptname (r):": "Název receptu (r):",
   "Zonenübersicht": "Přehled zón",
   "Generierter BVBS Code": "Vygenerovaný BVBS kód",

--- a/lang/de.json
+++ b/lang/de.json
@@ -71,6 +71,7 @@
   "Optionale (PREFORM 4.0) Daten": "Optionale (PREFORM 4.0) Daten",
   "Bügelname (s) - Zone 1": "Bügelname (s) - Zone 1",
   "Bügelname (s) - Zone 2": "Bügelname (s) - Zone 2",
+  "Bügelname": "Bügelname",
   "Rezeptname (r):": "Rezeptname (r):",
   "Zonenübersicht": "Zonenübersicht",
   "Generierter BVBS Code": "Generierter BVBS Code",

--- a/lang/en.json
+++ b/lang/en.json
@@ -71,6 +71,7 @@
   "Optionale (PREFORM 4.0) Daten": "Optional (PREFORM 4.0) Data",
   "Bügelname (s) - Zone 1": "Stirrup Name(s) - Zone 1",
   "Bügelname (s) - Zone 2": "Stirrup Name(s) - Zone 2",
+  "Bügelname": "Stirrup name",
   "Rezeptname (r):": "Recipe Name (r):",
   "Zonenübersicht": "Zone Overview",
   "Generierter BVBS Code": "Generated BVBS Code",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -64,6 +64,7 @@
   "Optionale (PREFORM 4.0) Daten": "Opcjonalne dane (PREFORM 4.0)",
   "Bügelname (s) - Zone 1": "Nazwa strzemienia (s) - Strefa 1",
   "Bügelname (s) - Zone 2": "Nazwa strzemienia (s) - Strefa 2",
+  "Bügelname": "Nazwa strzemienia",
   "Rezeptname (r):": "Nazwa receptury (r):",
   "Zonenübersicht": "Przegląd stref",
   "Generierter BVBS Code": "Wygenerowany kod BVBS",


### PR DESCRIPTION
## Summary
- display the stirrup name for each zone in the overview table
- refresh the summary and label preview when stirrup names change
- localize the new stirrup name label in all supported languages

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de2326c53c832d915260a7a3ab13b3