### PR TITLE
Add zone tooltip information to 3D viewer

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -2788,7 +2788,11 @@ function triggerPreviewUpdateDebounced() {
                             mainBarDiameter: parseFloat(document.getElementById('langdrahtDurchmesser').value) || 0,
                             initialOverhang: parseFloat(document.getElementById('anfangsueberstand').value) || 0,
                             finalOverhang: parseFloat(document.getElementById('endueberstand').value) || 0,
-                            zones: JSON.parse(JSON.stringify(zonesData)),
+                            zones: zonesData.map((zone, index) => ({
+                                ...zone,
+                                displayIndex: index + 1,
+                                effectiveNum: getEffectiveZoneNum(zone, index)
+                            })),
                             highlightedZoneDisplayIndex,
                             showOverhangs
                         };

--- a/styles.css
+++ b/styles.css
@@ -4318,6 +4318,58 @@ select.status-select.done {
     cursor: crosshair !important;
 }
 
+.viewer3d-zone-tooltip {
+    position: absolute;
+    top: 0;
+    left: 0;
+    padding: 0.5rem 0.65rem;
+    border-radius: 0.5rem;
+    background: rgba(15, 23, 42, 0.92);
+    color: #f9fafb;
+    font-size: 0.78rem;
+    line-height: 1.3;
+    pointer-events: none;
+    box-shadow: var(--shadow-sm);
+    display: none;
+    z-index: 14;
+    transition: opacity 0.12s ease;
+    opacity: 0;
+}
+
+.viewer3d-zone-tooltip.is-visible {
+    opacity: 1;
+}
+
+.viewer3d-zone-tooltip__title {
+    font-weight: 600;
+    font-size: 0.82rem;
+    margin-bottom: 0.25rem;
+}
+
+.viewer3d-zone-tooltip__list {
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+}
+
+.viewer3d-zone-tooltip__list div {
+    display: flex;
+    justify-content: space-between;
+    gap: 1.25rem;
+}
+
+.viewer3d-zone-tooltip__list dt {
+    margin: 0;
+    font-weight: 600;
+}
+
+.viewer3d-zone-tooltip__list dd {
+    margin: 0;
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+}
+
 .viewer3d-measure-label {
     position: absolute;
     min-width: 48px;


### PR DESCRIPTION
## Summary
- include display indices and effective stirrup counts in the generator payload for the 3D viewer
- render zone metadata in the viewer, showing a tooltip with diameter, count and spacing when hovering zones
- style the tooltip overlay so the data is easy to read inside the 3D canvas

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68de25c59d38832dae73293b65111b14