### PR TITLE
Tighten generator form field spacing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -435,7 +435,7 @@ select {
     padding: 1.25rem;
     display: flex;
     flex-direction: column;
-    gap: 1.25rem;
+    gap: 0.75rem;
 }
 
 .generator-inputs .collapsible-content.section-content-bg .form-group {
@@ -443,16 +443,7 @@ select {
 }
 
 .generator-inputs .collapsible-content.section-content-bg .form-group + .form-group {
-    padding-top: 0.35rem;
-    border-top: 1px solid var(--border-color);
-}
-
-.generator-inputs .collapsible-content.section-content-bg .form-group:not(:last-of-type) {
-    padding-bottom: 0.5rem;
-}
-
-.generator-inputs .collapsible-content.section-content-bg .form-group:last-of-type {
-    padding-bottom: 0;
+    margin-top: 0.75rem;
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
## Summary
- remove the dividing line between generator form groups and rely on spacing instead
- shrink the vertical gaps in generator sections for a more compact, uniform layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de6dd79dcc832dbc517c5c8b852ad9